### PR TITLE
Update Delete Command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -19,6 +19,8 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 
+    public static final String MESSAGE_INVALID_STUDENT_ID = "No student is found with Student ID: %1$s";
+
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -19,8 +19,6 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 
-    public static final String MESSAGE_INVALID_STUDENT_ID = "No student is found with Student ID: %1$s";
-
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -32,13 +32,13 @@ public class AddCommand extends Command {
             + PREFIX_COURSE + "COURSE "
             + PREFIX_TAG + "TAG\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_STUDENTID + "12345678"
+            + PREFIX_STUDENTID + "12345678 "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_COURSE + "Computer Science"
-            + PREFIX_TAG + "Student";
+            + PREFIX_COURSE + "Computer Science "
+            + PREFIX_TAG + "Student ";
 
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
-import static seedu.address.model.person.StudentId.isValidStudentId;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -13,7 +12,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentId;
-import seedu.address.model.person.exceptions.InvalidStudentIdException;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -30,6 +30,12 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_PERSON_NOT_FOUND = "No student is found with Student ID: %1$s";
     private final StudentId studentId;
 
+    /**
+     * Creates a DeleteCommand to delete the person identified by the specified {@code StudentId}.
+     *
+     * @param studentId The student ID of the person to be deleted.
+     * @throws NullPointerException if the {@code studentId} is null.
+     */
     public DeleteCommand(StudentId studentId) {
         requireNonNull(studentId);
         this.studentId = studentId;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -35,9 +35,6 @@ public class DeleteCommand extends Command {
 
     public DeleteCommand(StudentId studentId) {
         requireNonNull(studentId);
-        if (!isValidStudentId(studentId.studentId)) {
-            throw new InvalidStudentIdException(studentId.studentId);
-        }
         this.studentId = studentId;
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -77,7 +77,7 @@ public class DeleteCommand extends Command {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("studentId", studentId)
+                .add("targetStudentId", studentId)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -4,12 +4,16 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import seedu.address.commons.core.index.Index;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
+import static seedu.address.model.person.StudentId.isValidStudentId;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.StudentId;
+import seedu.address.model.person.exceptions.InvalidStudentIdException;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -19,28 +23,41 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the student identified by the Student ID used in the displayed person list.\n"
+            + "Parameters: "
+            + PREFIX_STUDENTID + "ID\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_STUDENTID + "12345678";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Student: %1$s";
 
-    private final Index targetIndex;
+    private final StudentId studentId;
 
-    public DeleteCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    public DeleteCommand(StudentId studentId) {
+        requireNonNull(studentId);
+        if (!isValidStudentId(studentId.studentId)) {
+            throw new InvalidStudentIdException(studentId.studentId);
+        }
+        this.studentId = studentId;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
+        Person personToDelete = null;
 
-        if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        for (Person person : lastShownList) {
+            if (person.getStudentId().equals(studentId)) {
+                personToDelete = person;
+                break;
+            }
         }
 
-        Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+        if (personToDelete == null) {
+            throw new CommandException(String.format(Messages.MESSAGE_INVALID_STUDENT_ID, studentId));
+        }
+
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }
@@ -57,13 +74,13 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return targetIndex.equals(otherDeleteCommand.targetIndex);
+        return studentId.equals(otherDeleteCommand.studentId);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("targetIndex", targetIndex)
+                .add("studentId", studentId)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -28,7 +28,7 @@ public class DeleteCommand extends Command {
             + PREFIX_STUDENTID + "12345678";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Student: %1$s";
-
+    public static final String MESSAGE_PERSON_NOT_FOUND = "No student is found with Student ID: %1$s";
     private final StudentId studentId;
 
     public DeleteCommand(StudentId studentId) {
@@ -40,21 +40,21 @@ public class DeleteCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
-        Person personToDelete = null;
+        Person toDelete = null;
 
         for (Person person : lastShownList) {
             if (person.getStudentId().equals(studentId)) {
-                personToDelete = person;
+                toDelete = person;
                 break;
             }
         }
 
-        if (personToDelete == null) {
-            throw new CommandException(String.format(Messages.MESSAGE_INVALID_STUDENT_ID, studentId));
+        if (toDelete == null) {
+            throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND, studentId));
         }
 
-        model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
+        model.deletePerson(toDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(toDelete)));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,10 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 
 import java.util.List;
-
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
@@ -36,6 +35,13 @@ public class DeleteCommand extends Command {
         this.studentId = studentId;
     }
 
+    /**
+     * Executes the delete command and removes a person identified by the given studentID.
+     *
+     * @param model the model that contains the data of persons
+     * @return a CommandResult that shows the outcome of the command
+     * @throws CommandException if the studentID is invalid or not found
+     */
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -25,7 +25,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             }
 
             String studentIdString = trimmedArg.substring(3).trim();
-            StudentId studentId = new StudentId(studentIdString);
+            StudentId studentId = ParserUtil.parseStudentId(studentIdString);
             return new DeleteCommand(studentId);
 
         } catch (IllegalArgumentException e) {

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -19,13 +19,19 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     public DeleteCommand parse(String args) throws ParseException {
         String trimmedArg = args.trim();
         try {
+            if (!trimmedArg.startsWith("id/")) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+
+            String studentIdString = trimmedArg.substring(3).trim();
 
             if (!StudentId.isValidStudentId(trimmedArg)) {
                 throw new ParseException(
                         String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
             }
 
-            StudentId studentId = new StudentId(trimmedArg);
+            StudentId studentId = new StudentId(studentIdString);
             return new DeleteCommand(studentId);
 
         } catch (IllegalArgumentException e) {

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -2,9 +2,9 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.StudentId;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
@@ -17,13 +17,21 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+        String trimmedArg = args.trim();
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
-        } catch (ParseException pe) {
+
+            if (!StudentId.isValidStudentId(trimmedArg)) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+
+            StudentId studentId = new StudentId(trimmedArg);
+            return new DeleteCommand(studentId);
+
+        } catch (IllegalArgumentException e) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), e);
         }
     }
-
 }
+

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -25,12 +25,6 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             }
 
             String studentIdString = trimmedArg.substring(3).trim();
-
-            if (!StudentId.isValidStudentId(trimmedArg)) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-            }
-
             StudentId studentId = new StudentId(studentIdString);
             return new DeleteCommand(studentId);
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -34,4 +34,3 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         }
     }
 }
-

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.Messages.*;
+import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.COURSE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -62,7 +62,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 00000000";
+        String deleteCommand = "delete id/00000000";
         assertCommandException(deleteCommand, String.format(MESSAGE_INVALID_STUDENT_ID, "00000000"));
     }
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,8 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
-import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.Messages.*;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.COURSE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -63,8 +62,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String deleteCommand = "delete 00000000";
+        assertCommandException(deleteCommand, String.format(MESSAGE_INVALID_STUDENT_ID, "00000000"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -63,7 +64,7 @@ public class LogicManagerTest {
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "delete id/00000000";
-        assertCommandException(deleteCommand, String.format(MESSAGE_INVALID_STUDENT_ID, "00000000"));
+        assertCommandException(deleteCommand, String.format(DeleteCommand.MESSAGE_PERSON_NOT_FOUND, "00000000"));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -67,7 +67,7 @@ public class DeleteCommandTest {
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
-    
+
     @Test
     public void equals() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -18,6 +18,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.StudentId;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -28,9 +29,10 @@ public class DeleteCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_validIndexUnfilteredList_success() {
+    public void execute_validStudentIdUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        StudentId studentIdToDelete = personToDelete.getStudentId();
+        DeleteCommand deleteCommand = new DeleteCommand(studentIdToDelete);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -42,19 +44,21 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+    public void execute_invalidStudentIdUnfilteredList_throwsCommandException() {
+        StudentId invalidStudentId = new StudentId("invalid123");
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        DeleteCommand deleteCommand = new DeleteCommand(invalidStudentId);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_STUDENT_ID);
     }
 
     @Test
-    public void execute_validIndexFilteredList_success() {
+    public void execute_validStudentIdFilteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        StudentId studentIdToDelete = personToDelete.getStudentId();
+        DeleteCommand deleteCommand = new DeleteCommand(studentIdToDelete);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
@@ -67,28 +71,43 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexFilteredList_throwsCommandException() {
+    public void execute_invalidStudentIdFilteredList_throwsCommandException() {
+//        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+//
+//        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+//        // ensures that outOfBoundIndex is still in bounds of address book list
+//        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+//
+//        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+//
+//        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+//
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of address book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+        StudentId invalidStudentId = new StudentId("invalid123");
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeleteCommand deleteCommand = new DeleteCommand(invalidStudentId);
 
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_STUDENT_ID);
+
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person secondPerson = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+
+        StudentId firstStudentId = firstPerson.getStudentId();
+        StudentId secondStudentId = secondPerson.getStudentId();
+
+        DeleteCommand deleteFirstCommand = new DeleteCommand(firstStudentId);
+        DeleteCommand deleteSecondCommand = new DeleteCommand(secondStudentId);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(firstStudentId);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -103,9 +122,11 @@ public class DeleteCommandTest {
 
     @Test
     public void toStringMethod() {
-        Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        StudentId targetStudentId = firstPerson.getStudentId();
+
+        DeleteCommand deleteCommand = new DeleteCommand(targetStudentId);
+        String expected = DeleteCommand.class.getCanonicalName() + "{targetStudentId=" + targetStudentId + "}";
         assertEquals(expected, deleteCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -45,11 +45,14 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidStudentIdUnfilteredList_throwsCommandException() {
-        StudentId invalidStudentId = new StudentId("invalid123");
+//        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+//        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+//
+//        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
+        StudentId invalidStudentId = new StudentId("12345679");
         DeleteCommand deleteCommand = new DeleteCommand(invalidStudentId);
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_STUDENT_ID);
+        assertCommandFailure(deleteCommand, model, String.format(Messages.MESSAGE_INVALID_STUDENT_ID, invalidStudentId));
     }
 
     @Test
@@ -81,14 +84,10 @@ public class DeleteCommandTest {
 //        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 //
 //        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-//
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
-        StudentId invalidStudentId = new StudentId("invalid123");
-
+        StudentId invalidStudentId = new StudentId("00000000");
         DeleteCommand deleteCommand = new DeleteCommand(invalidStudentId);
-
-        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_STUDENT_ID);
+        assertCommandFailure(deleteCommand, model, String.format(Messages.MESSAGE_INVALID_STUDENT_ID, invalidStudentId));
 
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -45,14 +45,9 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_invalidStudentIdUnfilteredList_throwsCommandException() {
-//        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-//        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-//
-//        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-
         StudentId invalidStudentId = new StudentId("12345679");
         DeleteCommand deleteCommand = new DeleteCommand(invalidStudentId);
-        assertCommandFailure(deleteCommand, model, String.format(Messages.MESSAGE_INVALID_STUDENT_ID, invalidStudentId));
+        assertCommandFailure(deleteCommand, model, String.format(DeleteCommand.MESSAGE_PERSON_NOT_FOUND, invalidStudentId));
     }
 
     @Test
@@ -72,25 +67,7 @@ public class DeleteCommandTest {
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
-
-    @Test
-    public void execute_invalidStudentIdFilteredList_throwsCommandException() {
-//        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-//
-//        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-//        // ensures that outOfBoundIndex is still in bounds of address book list
-//        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
-//
-//        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
-//
-//        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        StudentId invalidStudentId = new StudentId("00000000");
-        DeleteCommand deleteCommand = new DeleteCommand(invalidStudentId);
-        assertCommandFailure(deleteCommand, model, String.format(Messages.MESSAGE_INVALID_STUDENT_ID, invalidStudentId));
-
-    }
-
+    
     @Test
     public void equals() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -47,7 +47,8 @@ public class DeleteCommandTest {
     public void execute_invalidStudentIdUnfilteredList_throwsCommandException() {
         StudentId invalidStudentId = new StudentId("12345679");
         DeleteCommand deleteCommand = new DeleteCommand(invalidStudentId);
-        assertCommandFailure(deleteCommand, model, String.format(DeleteCommand.MESSAGE_PERSON_NOT_FOUND, invalidStudentId));
+        assertCommandFailure(
+                deleteCommand, model, String.format(DeleteCommand.MESSAGE_PERSON_NOT_FOUND, invalidStudentId));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -12,7 +12,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.commons.core.index.Index;
+//import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -25,6 +26,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.StudentId;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -48,9 +50,10 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_delete() throws Exception {
+        StudentId validStudentId = new StudentId("12345678");
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " " + PREFIX_STUDENTID + validStudentId);
+        assertEquals(new DeleteCommand(validStudentId), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.person.StudentId;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
@@ -22,7 +23,8 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+        StudentId validStudentId = new StudentId("12345678");
+        assertParseSuccess(parser, validStudentId.toString(), new DeleteCommand(validStudentId));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -23,7 +23,7 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         StudentId validStudentId = new StudentId("12345678");
-        String input = "id/" + validStudentId.toString();
+        String input = "id/" + validStudentId;
         assertParseSuccess(parser, input, new DeleteCommand(validStudentId));
     }
 

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -24,7 +24,8 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         StudentId validStudentId = new StudentId("12345678");
-        assertParseSuccess(parser, validStudentId.toString(), new DeleteCommand(validStudentId));
+        String input = "id/" + validStudentId.toString();
+        assertParseSuccess(parser, input, new DeleteCommand(validStudentId));
     }
 
     @Test


### PR DESCRIPTION
Introduces changes to the DeleteCommand, from deletion by index to deletion by studentID. 

**Key Changes:**

- Delete by studentID Instead of Index:
The DeleteCommand now removes contacts based on their studentID rather than an index in the list. This ensures greater accuracy, particularly when the list is filtered or modified, and prevents any reliance on shifting indices when modifying data.The command accepts a studentID as input, ensuring that the correct person is identified and removed, regardless of their position in the list.

**Removed Test:**
- Removed index-based deletion tests in `DeleteCommandTest:` 
Tests that relied on deleting a person by index have been removed, such as `execute_invalidIndexFilteredList_throwsCommandException()` and `execute_invalidIndexUnfilteredList_throwsCommandException()`, as they are no longer relevant to the updated DeleteCommand functionality. Deletion is now solely based on the studentID.

- New tests for studentID deletion: 
New tests have been added to verify the behavior of the DeleteCommand when deleting by studentID. The tests ensure the system behaves correctly when handling both valid and invalid studentIDs, and that no duplicate studentIDs can be added.

**Future Considerations:**

1. Deletion of Tutors Without a studentID: As the current structure requires all persons to have a studentID, handling Tutors without one remains a challenge. 

**Potential Solutions:**
1. Future changes may introduce a system where Tutors are assigned a default or optional studentID, ensuring they are handled appropriately during deletion.