### PR TITLE
Fix Ui not displaying StudentId bug

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -31,6 +31,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
+    private Label studentid;
+    @FXML
     private Label phone;
     @FXML
     private Label address;
@@ -49,6 +51,7 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
+        studentid.setText("StudentID: " + person.getStudentId().toString());
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,6 +28,7 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
+      <Label fx:id="studentid" styleClass="cell_small_label" text="\$studentid" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />


### PR DESCRIPTION
Previously, student id was not displaying on the student card. 
This is an issue since most of the commands require the user to
know the student id of the relevant students.

Student id display has an additional prefix "Student ID: ". 
This is to differentiate between student id and phone number,
both of which has the same format (8 digit number).