### PR TITLE
Add Module Command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GradeCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -78,8 +79,9 @@ public class GradeCommand extends Command {
             throw new CommandException(String.format(MESSAGE_MODULE_NOT_FOUND, module.value));
         }
 
-        person.setModuleGrade(module, grade);
-
+        Person updatedPerson = person.setModuleGrade(module, grade);
+        model.setPerson(person, updatedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, module));
     }
 

--- a/src/main/java/seedu/address/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GradeCommand.java
@@ -75,7 +75,7 @@ public class GradeCommand extends Command {
 
         ArrayList<Module> modules = person.getModules();
         if (!modules.contains(module)) {
-            throw new CommandException(String.format(MESSAGE_MODULE_NOT_FOUND, module));
+            throw new CommandException(String.format(MESSAGE_MODULE_NOT_FOUND, module.value));
         }
 
         person.setModuleGrade(module, grade);
@@ -101,7 +101,9 @@ public class GradeCommand extends Command {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("toAdd", module)
+                .add("studentId", studentId)
+                .add("module", module)
+                .add("toAdd", grade)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleCommand.java
@@ -1,57 +1,50 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Grade;
 import seedu.address.model.person.Module;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentId;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
+
 /**
  * Assigns a course-specific grade to a student.
  */
-public class GradeCommand extends Command {
+public class ModuleCommand extends Command {
 
-    public static final String COMMAND_WORD = "grade";
+    public static final String COMMAND_WORD = "module";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a course-specific grade to a student. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to a student. "
             + "Parameters: "
             + PREFIX_STUDENTID + "ID "
             + PREFIX_MODULE + "MODULE "
-            + PREFIX_GRADE + "GRADE "
             + "\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_STUDENTID + "12345678 "
-            + PREFIX_MODULE + "CS2103T "
-            + PREFIX_GRADE + "A+ ";
+            + PREFIX_MODULE + "CS2103T ";
 
     public static final String MESSAGE_SUCCESS = "New grade added for %1$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "This person does not exist in the address book";
-    public static final String MESSAGE_MODULE_NOT_FOUND = "The student does not take the module %1$s";
+    public static final String MESSAGE_DUPLICATE_MODULE = "The module %1$s already exists for this student";
 
     private final Module module;
     private final StudentId studentId;
-    private final Grade grade;
 
     /**
-     * Creates a GradeCommand to assign a grade to the specified {@code Module}
+     * Creates a ModuleCommand to add the specified {@code Module}
      */
-    public GradeCommand(StudentId studentId, Module module, Grade grade) {
+    public ModuleCommand(StudentId studentId, Module module) {
         requireNonNull(studentId);
         requireNonNull(module);
-        requireNonNull(grade);
         this.module = module;
         this.studentId = studentId;
-        this.grade = grade;
     }
 
     @Override
@@ -74,11 +67,11 @@ public class GradeCommand extends Command {
         }
 
         ArrayList<Module> modules = person.getModules();
-        if (!modules.contains(module)) {
-            throw new CommandException(String.format(MESSAGE_MODULE_NOT_FOUND, module));
+        if (modules.contains(module)) {
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_MODULE, module));
         }
 
-        person.setModuleGrade(module, grade);
+        person.addModule(module);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, module));
     }
@@ -90,12 +83,12 @@ public class GradeCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof GradeCommand)) {
+        if (!(other instanceof ModuleCommand)) {
             return false;
         }
 
-        GradeCommand otherGradeCommand = (GradeCommand) other;
-        return module.equals(otherGradeCommand.module);
+        ModuleCommand otherModuleCommand = (ModuleCommand) other;
+        return module.equals(otherModuleCommand.module);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleCommand.java
@@ -1,18 +1,18 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Module;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentId;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 
 /**
  * Assigns a course-specific grade to a student.
@@ -30,7 +30,7 @@ public class ModuleCommand extends Command {
             + PREFIX_STUDENTID + "12345678 "
             + PREFIX_MODULE + "CS2103T ";
 
-    public static final String MESSAGE_SUCCESS = "New grade added for %1$s";
+    public static final String MESSAGE_SUCCESS = "New module added for Student %1$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "This person does not exist in the address book";
     public static final String MESSAGE_DUPLICATE_MODULE = "The module %1$s already exists for this student";
 
@@ -68,12 +68,12 @@ public class ModuleCommand extends Command {
 
         ArrayList<Module> modules = person.getModules();
         if (modules.contains(module)) {
-            throw new CommandException(String.format(MESSAGE_DUPLICATE_MODULE, module));
+            throw new CommandException(String.format(MESSAGE_DUPLICATE_MODULE, module.value));
         }
 
         person.addModule(module);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, module));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, studentId));
     }
 
     @Override
@@ -94,6 +94,7 @@ public class ModuleCommand extends Command {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
+                .add("studentId", studentId)
                 .add("toAdd", module)
                 .toString();
     }

--- a/src/main/java/seedu/address/logic/commands/ModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -71,8 +72,9 @@ public class ModuleCommand extends Command {
             throw new CommandException(String.format(MESSAGE_DUPLICATE_MODULE, module.value));
         }
 
-        person.addModule(module);
-
+        Person updatedPerson = person.addModule(module);
+        model.setPerson(person, updatedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, studentId));
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.GradeCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ModuleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +81,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case ModuleCommand.COMMAND_WORD:
+            return new ModuleCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/GradeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GradeCommandParser.java
@@ -14,13 +14,13 @@ import seedu.address.model.person.Module;
 import seedu.address.model.person.StudentId;
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new GradeCommand object
  */
 public class GradeCommandParser implements Parser<GradeCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the GradeCommand
+     * and returns a GradeCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public GradeCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/ModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModuleCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ModuleCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Module;
+import seedu.address.model.person.StudentId;
+
+import java.util.stream.Stream;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
+
+/**
+ * Parses input arguments and creates a new ModuleCommand object
+ */
+public class ModuleCommandParser implements Parser<ModuleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ModuleCommand
+     * and returns a ModuleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ModuleCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_STUDENTID, PREFIX_MODULE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENTID, PREFIX_MODULE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STUDENTID, PREFIX_MODULE);
+        StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENTID).get());
+        Module module = ParserUtil.parseModule(argMultimap.getValue(PREFIX_MODULE).get());
+
+        return new ModuleCommand(studentId, module);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModuleCommandParser.java
@@ -1,15 +1,15 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
+
+import java.util.stream.Stream;
+
 import seedu.address.logic.commands.ModuleCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Module;
 import seedu.address.model.person.StudentId;
-
-import java.util.stream.Stream;
-
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 
 /**
  * Parses input arguments and creates a new ModuleCommand object

--- a/src/main/java/seedu/address/model/person/Grade.java
+++ b/src/main/java/seedu/address/model/person/Grade.java
@@ -17,7 +17,7 @@ public class Grade {
         "A+", "A", "A-", "B+", "B", "B-", "C+", "C", "D+", "D", "F"
     };
 
-    public final String grade;
+    public final String value;
 
     /**
      * Constructs an {@code Grade}.
@@ -27,7 +27,7 @@ public class Grade {
     public Grade(String grade) {
         requireNonNull(grade);
         checkArgument(isValidGrade(grade), MESSAGE_CONSTRAINTS);
-        this.grade = grade.toUpperCase(); // Store as uppercase
+        this.value = grade.toUpperCase(); // Store as uppercase
     }
 
     /**
@@ -45,7 +45,7 @@ public class Grade {
 
     @Override
     public String toString() {
-        return grade;
+        return value;
     }
 
     @Override
@@ -60,11 +60,11 @@ public class Grade {
         }
 
         Grade otherGrade = (Grade) other;
-        return grade.equals(otherGrade.grade);
+        return value.equals(otherGrade.value);
     }
 
     @Override
     public int hashCode() {
-        return grade.hashCode();
+        return value.hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/person/Module.java
+++ b/src/main/java/seedu/address/model/person/Module.java
@@ -18,7 +18,7 @@ public class Module {
      */
     public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]+$";
 
-    public final String module;
+    public final String value;
     private Grade grade;
 
     /**
@@ -29,7 +29,7 @@ public class Module {
     public Module(String module) {
         requireNonNull(module);
         checkArgument(isValidModule(module), MESSAGE_CONSTRAINTS);
-        this.module = module;
+        this.value = module;
     }
 
     /**
@@ -45,7 +45,7 @@ public class Module {
 
     @Override
     public String toString() {
-        return module + ": " + (grade == null ? "Grade not assigned" : grade.toString());
+        return value + ": " + (grade == null ? "Grade not assigned" : grade.toString());
     }
 
     @Override
@@ -60,11 +60,11 @@ public class Module {
         }
 
         Module otherModule = (Module) other;
-        return module.equals(otherModule.module);
+        return value.equals(otherModule.value);
     }
 
     @Override
     public int hashCode() {
-        return module.hashCode();
+        return value.hashCode();
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -25,7 +25,7 @@ public class Person {
     private final Address address;
     private final Course course;
     private final Tag tag;
-    private final ArrayList<Module> modules = new ArrayList<>();
+    private final ArrayList<Module> modules;
 
     /**
      * Every field must be present and not null.
@@ -40,6 +40,23 @@ public class Person {
         this.address = address;
         this.course = course;
         this.tag = tag;
+        this.modules = new ArrayList<>();
+    }
+
+    /**
+     * Facilitates creating new Person object with module list.
+     */
+    public Person(StudentId studentId, Name name, Phone phone, Email email, Address address, Course course,
+                  Tag tag, ArrayList<Module> modules) {
+        requireAllNonNull(studentId, name, phone, email, address, course, tag);
+        this.studentId = studentId;
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.course = course;
+        this.tag = tag;
+        this.modules = modules;
     }
 
     public StudentId getStudentId() {
@@ -77,27 +94,33 @@ public class Person {
     }
 
     /**
-     * Adds a module.
+     * Returns a new Person object with the module added.
      *
-     * @param module The module for which to add or update the grade.
+     * @param module The module to add.
      */
-    public void addModule(Module module) {
+    public Person addModule(Module module) {
         requireNonNull(module, "Module cannot be null");
-        modules.add(module);
+
+        ArrayList<Module> updatedModules = new ArrayList<>(modules);
+        updatedModules.add(module);
+        return new Person(studentId, name, phone, email, address, course, tag, updatedModules);
     }
 
     /**
-     * Sets a module grade.
+     * Returns a new Person object with the module grade set.
      *
-     * @param module The module for which to add or update the grade.
+     * @param module The module for which to update the grade.
      * @param grade The grade to associate with the module.
      */
-    public void setModuleGrade(Module module, Grade grade) {
+    public Person setModuleGrade(Module module, Grade grade) {
         requireNonNull(module, "Module cannot be null");
         requireNonNull(grade, "Grade cannot be null");
+
+        ArrayList<Module> updatedModules = new ArrayList<>(modules);
+        module.setGrade(grade);
         int index = modules.indexOf(module);
-        Module m = modules.get(index);
-        m.setGrade(grade);
+        updatedModules.set(index, module);
+        return new Person(studentId, name, phone, email, address, course, tag, updatedModules);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -77,7 +77,7 @@ public class Person {
     }
 
     /**
-     * Adds a module. If the module already exists, it updates the grade.
+     * Adds a module.
      *
      * @param module The module for which to add or update the grade.
      */
@@ -87,7 +87,7 @@ public class Person {
     }
 
     /**
-     * Sets a module grade. If the module already exists, it updates the grade.
+     * Sets a module grade.
      *
      * @param module The module for which to add or update the grade.
      * @param grade The grade to associate with the module.
@@ -95,7 +95,9 @@ public class Person {
     public void setModuleGrade(Module module, Grade grade) {
         requireNonNull(module, "Module cannot be null");
         requireNonNull(grade, "Grade cannot be null");
-        module.setGrade(grade);
+        int index = modules.indexOf(module);
+        Module m = modules.get(index);
+        m.setGrade(grade);
     }
 
     /**
@@ -169,6 +171,7 @@ public class Person {
                 .add("address", address)
                 .add("course", course)
                 .add("tag", tag)
+                .add("modules", modules)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -25,7 +25,7 @@ public class Person {
     private final Address address;
     private final Course course;
     private final Tag tag;
-    private final ArrayList<Module> moduleGrades = new ArrayList<>();
+    private final ArrayList<Module> modules = new ArrayList<>();
 
     /**
      * Every field must be present and not null.
@@ -67,34 +67,43 @@ public class Person {
     }
 
     /**
-     * Sets the module grades to the provided map.
+     * Sets the module to the provided list.
      *
-     * @param newModuleGrades A map of Module and Grade pairs to set.
+     * @param newModules A list of modules to set.
      */
-    public void setModuleGrades(ArrayList<Module> newModuleGrades) {
-        moduleGrades.clear();
-        moduleGrades.addAll(newModuleGrades);
+    public void setModules(ArrayList<Module> newModules) {
+        modules.clear();
+        modules.addAll(newModules);
     }
 
     /**
-     * Adds a module grade. If the module already exists, it updates the grade.
+     * Adds a module. If the module already exists, it updates the grade.
+     *
+     * @param module The module for which to add or update the grade.
+     */
+    public void addModule(Module module) {
+        requireNonNull(module, "Module cannot be null");
+        modules.add(module);
+    }
+
+    /**
+     * Sets a module grade. If the module already exists, it updates the grade.
      *
      * @param module The module for which to add or update the grade.
      * @param grade The grade to associate with the module.
      */
-    public void addModuleGrade(Module module, Grade grade) {
+    public void setModuleGrade(Module module, Grade grade) {
         requireNonNull(module, "Module cannot be null");
         requireNonNull(grade, "Grade cannot be null");
         module.setGrade(grade);
-        moduleGrades.add(module);
     }
 
     /**
      * Returns an immutable course grades map, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
-    public ArrayList<Module> getModuleGrades() {
-        return moduleGrades;
+    public ArrayList<Module> getModules() {
+        return modules;
     }
 
     /**
@@ -141,13 +150,13 @@ public class Person {
                 && address.equals(otherPerson.address)
                 && course.equals(otherPerson.course)
                 && tag.equals(otherPerson.tag)
-                && moduleGrades.equals(otherPerson.moduleGrades);
+                && modules.equals(otherPerson.modules);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(studentId, name, phone, email, address, course, tag, moduleGrades);
+        return Objects.hash(studentId, name, phone, email, address, course, tag, modules);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/StudentId.java
+++ b/src/main/java/seedu/address/model/person/StudentId.java
@@ -13,7 +13,7 @@ public class StudentId {
     public static final String MESSAGE_CONSTRAINTS =
             "StudentId should only contain numbers, and it should be exactly 8 digits long";
     public static final String VALIDATION_REGEX = "\\d{8}";
-    public final String studentId;
+    public final String value;
 
     /**
      * Constructs a {@code StudentId}.
@@ -23,7 +23,7 @@ public class StudentId {
     public StudentId(String studentId) {
         requireNonNull(studentId);
         checkArgument(isValidStudentId(studentId), MESSAGE_CONSTRAINTS);
-        this.studentId = studentId;
+        this.value = studentId;
     }
 
     /**
@@ -35,7 +35,7 @@ public class StudentId {
 
     @Override
     public String toString() {
-        return studentId;
+        return value;
     }
 
     @Override
@@ -50,12 +50,12 @@ public class StudentId {
         }
 
         StudentId otherStudentId = (StudentId) other;
-        return studentId.equals(otherStudentId.studentId);
+        return value.equals(otherStudentId.value);
     }
 
     @Override
     public int hashCode() {
-        return studentId.hashCode();
+        return value.hashCode();
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedGrade.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedGrade.java
@@ -25,7 +25,7 @@ class JsonAdaptedGrade {
      * Converts a given {@code Grade} into this class for Jackson use.
      */
     public JsonAdaptedGrade(Grade source) {
-        grade = source.grade;
+        grade = source.value;
     }
 
     @JsonValue

--- a/src/main/java/seedu/address/storage/JsonAdaptedModule.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedModule.java
@@ -25,7 +25,7 @@ class JsonAdaptedModule {
      * Converts a given {@code Module} into this class for Jackson use.
      */
     public JsonAdaptedModule(Module source) {
-        module = source.module;
+        module = source.value;
     }
 
     @JsonValue

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -52,7 +52,7 @@ class JsonAdaptedPerson {
      * Converts a given {@code Person} into this class for Jackson use.
      */
     public JsonAdaptedPerson(Person source) {
-        studentId = source.getStudentId().studentId;
+        studentId = source.getStudentId().value;
         name = source.getName().fullName;
         phone = source.getPhone().value;
         email = source.getEmail().value;

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -8,7 +8,7 @@ import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
 
 /**
- * An UI component that displays information of a {@code Person}.
+ * A UI component that displays information of a {@code Person}.
  */
 public class PersonCard extends UiPart<Region> {
 
@@ -31,7 +31,7 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
-    private Label studentid;
+    private Label studentId;
     @FXML
     private Label phone;
     @FXML
@@ -51,7 +51,7 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
-        studentid.setText("StudentID: " + person.getStudentId().toString());
+        studentId.setText("StudentID: " + person.getStudentId().studentId);
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
@@ -61,7 +61,7 @@ public class PersonCard extends UiPart<Region> {
         singleTagFlowPane.getChildren().add(tagLabel);
         tags.getChildren().add(singleTagFlowPane);
 
-        String modulesAsString = person.getModuleGrades().stream()
+        String modulesAsString = person.getModules().stream()
                 .map(m -> m.toString() + "\n")
                 .reduce("", (x, y) -> x + y);
 

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -51,7 +51,7 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
-        studentId.setText("StudentID: " + person.getStudentId().studentId);
+        studentId.setText("StudentID: " + person.getStudentId().value);
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -28,7 +28,7 @@
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
       <FlowPane fx:id="tags" />
-      <Label fx:id="studentid" styleClass="cell_small_label" text="\$studentid" />
+      <Label fx:id="studentId" styleClass="cell_small_label" text="\$studentId" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
@@ -42,6 +44,10 @@ public class CommandTestUtil {
     public static final String VALID_COURSE_BOB = "Physics";
     public static final String VALID_TAG_TUTOR = "Tutor";
     public static final String VALID_TAG_STUDENT = "Student";
+    public static final String VALID_MODULE_AMY = "CS2103T";
+    public static final String VALID_GRADE_AMY = "A";
+    public static final String VALID_MODULE_BOB = "CS2100";
+    public static final String VALID_GRADE_BOB = "B+";
 
     public static final String STUDENTID_DESC_AMY = " " + PREFIX_STUDENTID + VALID_STUDENTID_AMY;
     public static final String STUDENTID_DESC_BOB = " " + PREFIX_STUDENTID + VALID_STUDENTID_BOB;
@@ -57,6 +63,10 @@ public class CommandTestUtil {
     public static final String COURSE_DESC_BOB = " " + PREFIX_COURSE + VALID_COURSE_BOB;
     public static final String TAG_DESC_STUDENT = " " + PREFIX_TAG + VALID_TAG_STUDENT;
     public static final String TAG_DESC_TUTOR = " " + PREFIX_TAG + VALID_TAG_TUTOR;
+    public static final String MODULE_DESC_AMY = " " + PREFIX_MODULE + VALID_MODULE_AMY;
+    public static final String MODULE_DESC_BOB = " " + PREFIX_MODULE + VALID_MODULE_BOB;
+    public static final String GRADE_DESC_AMY = " " + PREFIX_GRADE + VALID_GRADE_AMY;
+    public static final String GRADE_DESC_BOB = " " + PREFIX_GRADE + VALID_GRADE_BOB;
 
     public static final String INVALID_STUDENTID_DESC = " " + PREFIX_STUDENTID
             + "@1234567"; // '@' not allowed in studentIds
@@ -66,6 +76,8 @@ public class CommandTestUtil {
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_COURSE_DESC = " " + PREFIX_COURSE + "2 Science"; // '2' not allowed in courses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_MODULE_DESC = " " + PREFIX_MODULE + "CS 2103T"; // ' ' not allowed in modules
+    public static final String INVALID_GRADE_DESC = " " + PREFIX_GRADE + "E"; // 'E' not allowed in grades
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/commands/GradeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GradeCommandTest.java
@@ -37,24 +37,23 @@ public class GradeCommandTest {
     @Test
     public void execute_gradeAcceptedByModel_addSuccessful() {
         Person student = model.getFilteredPersonList().get(0);
-        Person expectedStudent = new PersonBuilder(student).build();
-        StudentId studentId = student.getStudentId();
-        Module validModule = new Module(VALID_MODULE_AMY);
-        expectedStudent.addModule(validModule);
+        Person newStudent = new PersonBuilder(student).build();
 
-        Model newModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        newModel.setPerson(model.getFilteredPersonList().get(0), expectedStudent);
+        Module validModule = new Module(VALID_MODULE_AMY);
+        newStudent = newStudent.addModule(validModule);
+        model.setPerson(model.getFilteredPersonList().get(0), newStudent);
 
         Grade validGrade = new Grade(VALID_GRADE_AMY);
-        expectedStudent.setModuleGrade(validModule, validGrade);
+        newStudent = newStudent.setModuleGrade(validModule, validGrade);
+        StudentId studentId = student.getStudentId();
         GradeCommand gradeCommand = new GradeCommand(studentId, validModule, validGrade);
 
         String expectedMessage = String.format(GradeCommand.MESSAGE_SUCCESS, validModule);
 
-        Model expectedModel = new ModelManager(new AddressBook(newModel.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(newModel.getFilteredPersonList().get(0), expectedStudent);
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), newStudent);
 
-        assertCommandSuccess(gradeCommand, newModel, expectedMessage, expectedModel);
+        assertCommandSuccess(gradeCommand, model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/GradeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GradeCommandTest.java
@@ -1,0 +1,122 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GRADE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GRADE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENTID_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENTID_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Grade;
+import seedu.address.model.person.Module;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StudentId;
+import seedu.address.testutil.PersonBuilder;
+
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for GradeCommand.
+ */
+public class GradeCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_gradeAcceptedByModel_addSuccessful() {
+        Person student = model.getFilteredPersonList().get(0);
+        Person expectedStudent = new PersonBuilder(student).build();
+        StudentId studentId = student.getStudentId();
+        Module validModule = new Module(VALID_MODULE_AMY);
+        expectedStudent.addModule(validModule);
+
+        Model newModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        newModel.setPerson(model.getFilteredPersonList().get(0), expectedStudent);
+
+        Grade validGrade = new Grade(VALID_GRADE_AMY);
+        expectedStudent.setModuleGrade(validModule, validGrade);
+        GradeCommand gradeCommand = new GradeCommand(studentId, validModule, validGrade);
+
+        String expectedMessage = String.format(GradeCommand.MESSAGE_SUCCESS, validModule);
+
+        Model expectedModel = new ModelManager(new AddressBook(newModel.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(newModel.getFilteredPersonList().get(0), expectedStudent);
+
+        assertCommandSuccess(gradeCommand, newModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_studentNotFound_throwsCommandException() {
+        StudentId invalidStudentId = new StudentId("99999999"); // id that doesn't exist in the address book
+        Module validModule = new Module(VALID_MODULE_AMY);
+        Grade validGrade = new Grade(VALID_GRADE_AMY);
+        GradeCommand gradeCommand = new GradeCommand(invalidStudentId, validModule, validGrade);
+
+        assertThrows(CommandException.class, GradeCommand.MESSAGE_PERSON_NOT_FOUND, () -> gradeCommand.execute(model));
+    }
+
+    @Test
+    public void execute_moduleNotFound_throwsCommandException() {
+        Person student = model.getFilteredPersonList().get(0);
+        StudentId studentId = student.getStudentId();
+        Module invalidModule = new Module(VALID_MODULE_BOB);
+        Grade validGrade = new Grade(VALID_GRADE_AMY);
+        GradeCommand gradeCommand = new GradeCommand(studentId, invalidModule, validGrade);
+
+        assertThrows(CommandException.class,
+                String.format(GradeCommand.MESSAGE_MODULE_NOT_FOUND, invalidModule.value), ()
+                        -> gradeCommand.execute(model));
+    }
+
+    @Test
+    public void equals() {
+        StudentId amyId = new StudentId(VALID_STUDENTID_AMY);
+        StudentId bobId = new StudentId(VALID_STUDENTID_BOB);
+        Module amyModule = new Module(VALID_MODULE_AMY);
+        Module bobModule = new Module(VALID_MODULE_BOB);
+        Grade amyGrade = new Grade(VALID_GRADE_AMY);
+        Grade bobGrade = new Grade(VALID_GRADE_BOB);
+        GradeCommand addAmyGradeCommand = new GradeCommand(amyId, amyModule, amyGrade);
+        GradeCommand addBobGradeCommand = new GradeCommand(bobId, bobModule, bobGrade);
+
+        // same object -> returns true
+        assertTrue(addAmyGradeCommand.equals(addAmyGradeCommand));
+
+        // same values -> returns true
+        GradeCommand addAliceGradeCommandCopy = new GradeCommand(amyId, amyModule, amyGrade);
+        assertTrue(addAmyGradeCommand.equals(addAliceGradeCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addAmyGradeCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addAmyGradeCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(addAmyGradeCommand.equals(addBobGradeCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        StudentId studentId = new StudentId(VALID_STUDENTID_AMY);
+        Module module = new Module(VALID_MODULE_AMY);
+        Grade grade = new Grade(VALID_GRADE_AMY);
+        GradeCommand gradeCommand = new GradeCommand(studentId, module, grade);
+        String expected = GradeCommand.class.getCanonicalName()
+                + "{studentId=" + studentId + ", module=" + module + ", toAdd=" + grade + "}";
+        assertEquals(expected, gradeCommand.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ModuleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ModuleCommandTest.java
@@ -36,7 +36,7 @@ public class ModuleCommandTest {
         Person expectedStudent = new PersonBuilder(student).build();
         StudentId studentId = student.getStudentId();
         Module validModule = new Module(VALID_MODULE_AMY);
-        expectedStudent.addModule(validModule);
+        expectedStudent = expectedStudent.addModule(validModule);
         ModuleCommand moduleCommand = new ModuleCommand(studentId, validModule);
 
         String expectedMessage = String.format(ModuleCommand.MESSAGE_SUCCESS, studentId);
@@ -51,17 +51,15 @@ public class ModuleCommandTest {
     public void execute_duplicateModule_throwsCommandException() {
         Person student = model.getFilteredPersonList().get(0);
         Person expectedStudent = new PersonBuilder(student).build();
-        StudentId studentId = student.getStudentId();
         Module validModule = new Module(VALID_MODULE_AMY);
-        expectedStudent.addModule(validModule);
+        expectedStudent = expectedStudent.addModule(validModule);
+        model.setPerson(model.getFilteredPersonList().get(0), expectedStudent);
+
+        StudentId studentId = student.getStudentId();
         ModuleCommand moduleCommand = new ModuleCommand(studentId, validModule);
-
-        Model newModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        newModel.setPerson(model.getFilteredPersonList().get(0), expectedStudent);
-
         assertThrows(CommandException.class,
             String.format(ModuleCommand.MESSAGE_DUPLICATE_MODULE, VALID_MODULE_AMY), ()
-                -> moduleCommand.execute(newModel));
+                -> moduleCommand.execute(model));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ModuleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ModuleCommandTest.java
@@ -1,0 +1,113 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENTID_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENTID_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Module;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.StudentId;
+import seedu.address.testutil.PersonBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ModuleCommand.
+ */
+public class ModuleCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_moduleAcceptedByModel_addSuccessful() {
+        Person student = model.getFilteredPersonList().get(0);
+        Person expectedStudent = new PersonBuilder(student).build();
+        StudentId studentId = student.getStudentId();
+        Module validModule = new Module(VALID_MODULE_AMY);
+        expectedStudent.addModule(validModule);
+        ModuleCommand moduleCommand = new ModuleCommand(studentId, validModule);
+
+        String expectedMessage = String.format(ModuleCommand.MESSAGE_SUCCESS, studentId);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), expectedStudent);
+
+        assertCommandSuccess(moduleCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_duplicateModule_throwsCommandException() {
+        Person student = model.getFilteredPersonList().get(0);
+        Person expectedStudent = new PersonBuilder(student).build();
+        StudentId studentId = student.getStudentId();
+        Module validModule = new Module(VALID_MODULE_AMY);
+        expectedStudent.addModule(validModule);
+        ModuleCommand moduleCommand = new ModuleCommand(studentId, validModule);
+
+        Model newModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        newModel.setPerson(model.getFilteredPersonList().get(0), expectedStudent);
+
+        assertThrows(CommandException.class,
+            String.format(ModuleCommand.MESSAGE_DUPLICATE_MODULE, VALID_MODULE_AMY), ()
+                -> moduleCommand.execute(newModel));
+    }
+
+    @Test
+    public void execute_studentNotFound_throwsCommandException() {
+        StudentId invalidStudentId = new StudentId("99999999"); // id that doesn't exist in the address book
+        Module validModule = new Module(VALID_MODULE_AMY);
+        ModuleCommand moduleCommand = new ModuleCommand(invalidStudentId, validModule);
+
+        assertThrows(CommandException.class, ModuleCommand.MESSAGE_PERSON_NOT_FOUND, ()
+                -> moduleCommand.execute(model));
+    }
+
+    @Test
+    public void equals() {
+        StudentId amyId = new StudentId(VALID_STUDENTID_AMY);
+        StudentId bobId = new StudentId(VALID_STUDENTID_BOB);
+        Module amyModule = new Module(VALID_MODULE_AMY);
+        Module bobModule = new Module(VALID_MODULE_BOB);
+        ModuleCommand addAmyModuleCommand = new ModuleCommand(amyId, amyModule);
+        ModuleCommand addBobModuleCommand = new ModuleCommand(bobId, bobModule);
+
+        // same object -> returns true
+        assertTrue(addAmyModuleCommand.equals(addAmyModuleCommand));
+
+        // same values -> returns true
+        ModuleCommand addAliceModuleCommandCopy = new ModuleCommand(amyId, amyModule);
+        assertTrue(addAmyModuleCommand.equals(addAliceModuleCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addAmyModuleCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addAmyModuleCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(addAmyModuleCommand.equals(addBobModuleCommand));
+    }
+
+    @Test
+    public void toStringMethod() {
+        StudentId studentId = new StudentId(VALID_STUDENTID_AMY);
+        Module module = new Module(VALID_MODULE_AMY);
+        ModuleCommand moduleCommand = new ModuleCommand(studentId, module);
+        String expected = ModuleCommand.class.getCanonicalName()
+                + "{studentId=" + studentId + ", toAdd=" + module + "}";
+        assertEquals(expected, moduleCommand.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/GradeCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GradeCommandParserTest.java
@@ -1,0 +1,136 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.GRADE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.GRADE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_GRADE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_STUDENTID_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_GRADE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENTID_BOB;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.GradeCommand;
+import seedu.address.model.person.Grade;
+import seedu.address.model.person.Module;
+import seedu.address.model.person.StudentId;
+
+public class GradeCommandParserTest {
+    private GradeCommandParser parser = new GradeCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        StudentId expectedStudentId = new StudentId(VALID_STUDENTID_BOB);
+        Module expectedModule = new Module(VALID_MODULE_BOB);
+        Grade expectedGrade = new Grade(VALID_GRADE_BOB);
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + STUDENTID_DESC_BOB + MODULE_DESC_BOB + GRADE_DESC_BOB,
+                new GradeCommand(expectedStudentId, expectedModule, expectedGrade));
+    }
+
+    @Test
+    public void parse_repeatedNonTagValue_failure() {
+        String validExpectedGradeString = STUDENTID_DESC_AMY + MODULE_DESC_AMY + GRADE_DESC_AMY;
+
+        // multiple studentIds
+        assertParseFailure(parser, STUDENTID_DESC_AMY + validExpectedGradeString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+
+        // multiple modules
+        assertParseFailure(parser, MODULE_DESC_AMY + validExpectedGradeString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULE));
+
+        // multiple grades
+        assertParseFailure(parser, GRADE_DESC_AMY + validExpectedGradeString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_GRADE));
+
+        // multiple fields repeated
+        assertParseFailure(parser,
+                validExpectedGradeString + STUDENTID_DESC_AMY + MODULE_DESC_AMY + GRADE_DESC_AMY
+                        + validExpectedGradeString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID, PREFIX_MODULE, PREFIX_GRADE));
+
+        // invalid value followed by valid value
+
+        // invalid studentId
+        assertParseFailure(parser, INVALID_STUDENTID_DESC + validExpectedGradeString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+
+        // invalid module
+        assertParseFailure(parser, INVALID_MODULE_DESC + validExpectedGradeString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULE));
+
+        // invalid grade
+        assertParseFailure(parser, INVALID_GRADE_DESC + validExpectedGradeString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_GRADE));
+
+        // valid value followed by invalid value
+
+        // invalid studentId
+        assertParseFailure(parser, validExpectedGradeString + INVALID_STUDENTID_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+
+        // invalid module
+        assertParseFailure(parser, validExpectedGradeString + INVALID_MODULE_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULE));
+
+        // invalid grade
+        assertParseFailure(parser, validExpectedGradeString + INVALID_GRADE_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_GRADE));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeCommand.MESSAGE_USAGE);
+
+        // missing studentId prefix
+        assertParseFailure(parser, VALID_STUDENTID_BOB + MODULE_DESC_BOB + GRADE_DESC_BOB, expectedMessage);
+
+        // missing module prefix
+        assertParseFailure(parser, STUDENTID_DESC_BOB + VALID_MODULE_BOB + GRADE_DESC_BOB, expectedMessage);
+
+        // missing module prefix
+        assertParseFailure(parser, STUDENTID_DESC_BOB + MODULE_DESC_BOB + VALID_GRADE_BOB, expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_STUDENTID_BOB + VALID_MODULE_BOB + VALID_GRADE_BOB, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid studentId
+        assertParseFailure(parser, INVALID_STUDENTID_DESC + MODULE_DESC_BOB + GRADE_DESC_BOB,
+                StudentId.MESSAGE_CONSTRAINTS);
+
+        // invalid module
+        assertParseFailure(parser, STUDENTID_DESC_BOB + INVALID_MODULE_DESC + GRADE_DESC_BOB,
+                Module.MESSAGE_CONSTRAINTS);
+
+        // invalid grade
+        assertParseFailure(parser, STUDENTID_DESC_BOB + MODULE_DESC_BOB + INVALID_GRADE_DESC,
+                Grade.MESSAGE_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_STUDENTID_DESC + INVALID_MODULE_DESC + GRADE_DESC_BOB,
+                StudentId.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + STUDENTID_DESC_BOB + MODULE_DESC_BOB + GRADE_DESC_BOB,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ModuleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ModuleCommandParserTest.java
@@ -1,0 +1,107 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_STUDENTID_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENTID_BOB;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.ModuleCommand;
+import seedu.address.model.person.Module;
+import seedu.address.model.person.StudentId;
+
+public class ModuleCommandParserTest {
+    private ModuleCommandParser parser = new ModuleCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        StudentId expectedStudentId = new StudentId(VALID_STUDENTID_BOB);
+        Module expectedModule = new Module(VALID_MODULE_BOB);
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + STUDENTID_DESC_BOB + MODULE_DESC_BOB,
+                new ModuleCommand(expectedStudentId, expectedModule));
+    }
+
+    @Test
+    public void parse_repeatedNonTagValue_failure() {
+        String validExpectedModuleString = STUDENTID_DESC_AMY + MODULE_DESC_AMY;
+
+        // multiple studentIds
+        assertParseFailure(parser, STUDENTID_DESC_AMY + validExpectedModuleString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+
+        // multiple modules
+        assertParseFailure(parser, MODULE_DESC_AMY + validExpectedModuleString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULE));
+
+        // multiple fields repeated
+        assertParseFailure(parser,
+                validExpectedModuleString + STUDENTID_DESC_AMY + MODULE_DESC_AMY + validExpectedModuleString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID, PREFIX_MODULE));
+
+        // invalid value followed by valid value
+
+        // invalid studentId
+        assertParseFailure(parser, INVALID_STUDENTID_DESC + validExpectedModuleString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+
+        // invalid module
+        assertParseFailure(parser, INVALID_MODULE_DESC + validExpectedModuleString,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULE));
+
+        // valid value followed by invalid value
+
+        // invalid studentId
+        assertParseFailure(parser, validExpectedModuleString + INVALID_STUDENTID_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+
+        // invalid module
+        assertParseFailure(parser, validExpectedModuleString + INVALID_MODULE_DESC,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULE));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleCommand.MESSAGE_USAGE);
+
+        // missing studentId prefix
+        assertParseFailure(parser, VALID_STUDENTID_BOB + MODULE_DESC_BOB, expectedMessage);
+
+        // missing module prefix
+        assertParseFailure(parser, STUDENTID_DESC_BOB + VALID_MODULE_BOB, expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_STUDENTID_BOB + VALID_MODULE_BOB, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid studentId
+        assertParseFailure(parser, INVALID_STUDENTID_DESC + MODULE_DESC_BOB, StudentId.MESSAGE_CONSTRAINTS);
+
+        // invalid module
+        assertParseFailure(parser, STUDENTID_DESC_BOB + INVALID_MODULE_DESC, Module.MESSAGE_CONSTRAINTS);
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_STUDENTID_DESC + INVALID_MODULE_DESC,
+                StudentId.MESSAGE_CONSTRAINTS);
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + STUDENTID_DESC_BOB + MODULE_DESC_BOB,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -100,7 +100,7 @@ public class PersonTest {
         String expected = Person.class.getCanonicalName() + "{studentId=" + ALICE.getStudentId() + ", name="
                 + ALICE.getName() + ", phone=" + ALICE.getPhone()
                 + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", course=" + ALICE.getCourse()
-                + ", tag=" + ALICE.getTag() + "}";
+                + ", tag=" + ALICE.getTag() + ", modules=" + ALICE.getModules() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,8 +1,11 @@
 package seedu.address.testutil;
 
+import java.util.ArrayList;
+
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Course;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -30,6 +33,8 @@ public class PersonBuilder {
     private Address address;
     private Course course;
     private Tag tag;
+    private ArrayList<Module> modules;
+
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -42,6 +47,7 @@ public class PersonBuilder {
         address = new Address(DEFAULT_ADDRESS);
         course = new Course(DEFAULT_COURSE);
         tag = new Tag(DEFAULT_TAG);
+        modules = new ArrayList<>();
     }
 
     /**
@@ -55,6 +61,7 @@ public class PersonBuilder {
         address = personToCopy.getAddress();
         course = personToCopy.getCourse();
         tag = personToCopy.getTag();
+        modules = personToCopy.getModules();
     }
 
     /**
@@ -113,7 +120,20 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Module} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withModule(String module) {
+        this.modules.add(new Module(module));
+        return this;
+    }
+
+    /**
+     * Builds the {@code Person}.
+     */
     public Person build() {
-        return new Person(studentId, name, phone, email, address, course, tag);
+        Person p = new Person(studentId, name, phone, email, address, course, tag);
+        p.setModules(modules);
+        return p;
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -121,14 +121,6 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Module} of the {@code Person} that we are building.
-     */
-    public PersonBuilder withModule(String module) {
-        this.modules.add(new Module(module));
-        return this;
-    }
-
-    /**
      * Builds the {@code Person}.
      */
     public Person build() {

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -29,7 +29,7 @@ public class PersonUtil {
      */
     public static String getPersonDetails(Person person) {
         StringBuilder sb = new StringBuilder();
-        sb.append(PREFIX_STUDENTID + person.getStudentId().studentId + " ");
+        sb.append(PREFIX_STUDENTID + person.getStudentId().value + " ");
         sb.append(PREFIX_NAME + person.getName().fullName + " ");
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
@@ -44,7 +44,7 @@ public class PersonUtil {
      */
     public static String getEditPersonDescriptorDetails(EditPersonDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getStudentId().ifPresent(studentId -> sb.append(PREFIX_STUDENTID).append(studentId.studentId)
+        descriptor.getStudentId().ifPresent(studentId -> sb.append(PREFIX_STUDENTID).append(studentId.value)
                 .append(" "));
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));


### PR DESCRIPTION
Currently, only the GradeCommand supports adding a module to a student.

Considering teachers only grade students towards the end of the module, it is important to allow users to add modules to students without the grade.

Changes made in the PR include:
  1. adding a ModuleCommand class to facilitate adding a module without a grade to the specified Person's list of modules.
  2. adding a ModuleCommandParser class to parse the newly-added module command.
  3. refactoring GradeCommand class such that it now
     - requires the specified Module to be present in the specified Person's list of modules.
     - has accurate JavaDocs
  4. refactoring GradeCommandParser class to support the changes made to the GradeCommand class.
  5. refactoring Person class such that it supports the changes and additions made in this commit.
  6. adding new test cases for the following classes:
     - GradeCommand
     - GradeCommandParser
     - ModuleCommand
     - ModuleCommandParser
  7. adding constants to CommandTestUtil class to facilitate testing.
  8. refactoring toString method of Person class to include module field.
  9. refactoring PersonBuilder class to include module field.
  10. refactoring public final fields of StudentId, Module and Grade classes to "value" to standardize across all attribute classes.
  11. capitalising the I in studentId in PersonCard class and PersonListCard.fxml file to standardize across the rest of the code base.

Things of Note:
- ModuleCommand and GradeCommand updates a student by creating a new Person object and replacing the student with the new Person object, similar to how EditCommand performs edits.
- Similar to EditCommandTest, ModuleCommandTest and GradeCommandTest assumes that the studentId 99999999 does not exist in the typical address book.
- A student's modules is still represented by an ArrayList, which may need to change to accommodate for Storage implementation.