### PR TITLE
Remove id prefix & add Delete by Module

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -4,9 +4,9 @@
   pageNav: 3
 ---
 
-# AB-3 User Guide
+# EduContacts User Guide
 
-AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized for use via a  Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, AB3 can get your contact management tasks done faster than traditional GUI apps.
+EduContacts is a **desktop app for Educators in Tertiary Institution to manage contacts, optimized for use via a  Line Interface** (CLI) while still having the benefits of a Graphical User Interface (GUI). If you can type fast, AB3 can get your contact management tasks done faster than traditional GUI apps.
 
 <!-- * Table of Contents -->
 <page-nav-print />
@@ -21,7 +21,7 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 
 1. Copy the file to the folder you want to use as the _home folder_ for your AddressBook.
 
-1. Open a command terminal, `cd` into the folder you put the jar file in, and use the `java -jar addressbook.jar` command to run the application.<br>
+1. Open a command terminal, `cd` into the folder you put the jar file in, and use the `java -jar educontacts.jar` command to run the application.<br>
    A GUI similar to the below should appear in a few seconds. Note how the app contains some sample data.<br>
    ![Ui](images/Ui.png)
 
@@ -30,9 +30,9 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 
    * `list` : Lists all contacts.
 
-   * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01` : Adds a contact named `John Doe` to the Address Book.
+   * `add 12345678 n/John Doe p/99999999 e/johndoe@example.com a/123 Jane Doe Road c/Computer Science t/Student` : Adds a contact named `John Doe` to EduContacts.
 
-   * `delete 3` : Deletes the 3rd contact shown in the current list.
+   * `delete 12345678` : Deletes a student contact with StudentID `12345678`.
 
    * `clear` : Deletes all contacts.
 
@@ -51,17 +51,14 @@ AddressBook Level 3 (AB3) is a **desktop app for managing contacts, optimized fo
 * Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
-* Items in square brackets are optional.<br>
-  e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
-
-* Items with `…`​ after them can be used multiple times including zero times.<br>
-  e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
 
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
+
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
+
 
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </box>
@@ -79,16 +76,11 @@ Format: `help`
 
 Adds a person to the address book.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​`
-
-<box type="tip" seamless>
-
-**Tip:** A person can have any number of tags (including 0)
-</box>
+Format: `add ID n/NAME p/PHONE e/EMAIL a/ADDRESS c/COURSE t/TAG`
 
 Examples:
-* `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
-* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal`
+* `add 12345678 n/John Doe p/99999999 e/johndoe@example.com a/123 Jane Doe Road c/Computer Science t/Student`
+* `add 87654321 n/Betsy Crowe t/ Student e/betsycrowe@example.com a/Newgate Prison p/1234567 c/Business Analytics`
 
 ### Listing all persons : `list`
 
@@ -100,50 +92,45 @@ Format: `list`
 
 Edits an existing person in the address book.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
+Format: `edit ID [FIELD_TO_EDIT_PREFIX] [NEW_VALUE]`
 
-* Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
+* Edits a student's details according to the fields specified.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
-* When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
-* You can remove all the person’s tags by typing `t/` without
-    specifying any tags after it.
+
 
 Examples:
-*  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
-*  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
+*  `edit 12345678 m/CS2103T CS2101`
 
-### Locating persons by name: `find`
+### Listing students by certain attributes : `filter`
 
-Finds persons whose names contain any of the given keywords.
+Filter students based on their Names, Courses and Modules.
 
-Format: `find KEYWORD [MORE_KEYWORDS]`
+Format: `filter [KEYWORD_PREFIX] [MORE_KEYWORDS]`
 
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only the name is searched.
 * Only full words will be matched e.g. `Han` will not match `Hans`
 * Persons matching at least one keyword will be returned (i.e. `OR` search).
   e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
 
 Examples:
-* `find John` returns `john` and `John Doe`
-* `find alex david` returns `Alex Yeoh`, `David Li`<br>
+* `filter n/John` returns `john` and `John Doe`
+* `filter n/alex david` returns `Alex Yeoh`, `David Li`
+* `filter m/CS2103T` returns a list of all students with module CS2103T. 
+* `filter c/Computer Science` returns a list of all students with course Computer Science.<br>
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 
 ### Deleting a person : `delete`
 
 Deletes the specified person from the address book.
 
-Format: `delete INDEX`
+Format: `delete ID`
 
-* Deletes the person at the specified `INDEX`.
-* The index refers to the index number shown in the displayed person list.
-* The index **must be a positive integer** 1, 2, 3, …​
+* Deletes student with the specified `ID`.
 
 Examples:
-* `list` followed by `delete 2` deletes the 2nd person in the address book.
-* `find Betsy` followed by `delete 1` deletes the 1st person in the results of the `find` command.
+* `delete 12345678` will delete student contact with `ID: 12345678`.
 
 ### Clearing all entries : `clear`
 
@@ -159,7 +146,7 @@ Format: `exit`
 
 ### Saving the data
 
-AddressBook data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.
+EduContacts data are saved in the hard disk automatically after any command that changes the data. There is no need to save manually.
 
 ### Editing the data file
 
@@ -196,10 +183,10 @@ _Details coming soon ..._
 
 Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-**Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
+**Add**    | `add ID n/NAME p/PHONE e/EMAIL a/ADDRESS c/COURSE t/TAG` <br> e.g., `add 12345678 n/John Doe p/99999999 e/johndoe@example.com a/123 Jane Doe Road c/Computer Science t/Student`
 **Clear**  | `clear`
-**Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
-**Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
+**Delete** | `delete ID`<br> e.g., `delete 12345678`
+**Edit**   | `edit ID [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [c/COURSE] [t/TAG]…​`<br> e.g.,`edit 12345678 p/91234567 e/johndoe@example.com`
+**Filter**   | `find [n/NAME] [c/COURSE] [m/MODULE]`<br> e.g., `find n/James Jake`
 **List**   | `list`
 **Help**   | `help`

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -19,6 +19,8 @@ public class Messages {
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_DUPLICATE_STUDENTID =
+            "Multiple student IDs specified. Only one student ID is allowed.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.
@@ -30,6 +32,13 @@ public class Messages {
                 Stream.of(duplicatePrefixes).map(Prefix::toString).collect(Collectors.toSet());
 
         return MESSAGE_DUPLICATE_FIELDS + String.join(" ", duplicateFields);
+    }
+
+    /**
+     * Returns an error message indicating multiple student IDs were provided.
+     */
+    public static String getErrorMessageForDuplicateID() {
+        return MESSAGE_DUPLICATE_STUDENTID;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
@@ -24,7 +23,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
             + "Parameters: "
-            + PREFIX_STUDENTID + "ID "
+            + "ID "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
@@ -32,7 +31,7 @@ public class AddCommand extends Command {
             + PREFIX_COURSE + "COURSE "
             + PREFIX_TAG + "TAG\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_STUDENTID + "12345678 "
+            + "12345678 "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 
 import java.util.List;
 
@@ -9,6 +8,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentId;
 
@@ -20,25 +20,42 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the student identified by the Student ID used in the displayed person list.\n"
+            + ": Deletes the student identified by the Student ID used in the displayed person list,\n"
+            + "or deletes a module from the person's module list.\n"
             + "Parameters: "
-            + PREFIX_STUDENTID + "ID\n"
+            + "ID\n"
+            + "or: "
+            + "ID MODULE_KEYWORD"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_STUDENTID + "12345678";
+            + "12345678"
+            + "or: " + COMMAND_WORD + " "
+            + "12345678 m/CS2103T";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Student: %1$s";
+    public static final String MESSAGE_DELETE_MODULE_SUCCESS = "Deleted Module: %1$s";
+
     public static final String MESSAGE_PERSON_NOT_FOUND = "No student is found with Student ID: %1$s";
+    public static final String MESSAGE_MODULE_NOT_FOUND = "No module is found for this student: %1$s";
     private final StudentId studentId;
+    private final Module module;
 
     /**
      * Creates a DeleteCommand to delete the person identified by the specified {@code StudentId}.
-     *
-     * @param studentId The student ID of the person to be deleted.
-     * @throws NullPointerException if the {@code studentId} is null.
      */
     public DeleteCommand(StudentId studentId) {
         requireNonNull(studentId);
         this.studentId = studentId;
+        this.module = null;
+    }
+
+    /**
+     * Creates a DeleteCommand to delete the module by the specified {@code Module}.
+     */
+    public DeleteCommand(StudentId studentId, Module module) {
+        requireNonNull(studentId);
+        requireNonNull(module);
+        this.studentId = studentId;
+        this.module = module;
     }
 
     /**
@@ -65,6 +82,14 @@ public class DeleteCommand extends Command {
             throw new CommandException(String.format(MESSAGE_PERSON_NOT_FOUND, studentId));
         }
 
+        if (module != null) {
+            if (!toDelete.hasModule(module)) {
+                throw new CommandException(String.format(MESSAGE_MODULE_NOT_FOUND, toDelete.getStudentId()));
+            }
+            model.deleteModule(toDelete, module);
+            return new CommandResult(String.format(MESSAGE_DELETE_MODULE_SUCCESS, module.toString()));
+        }
+
         model.deletePerson(toDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(toDelete)));
     }
@@ -81,13 +106,17 @@ public class DeleteCommand extends Command {
         }
 
         DeleteCommand otherDeleteCommand = (DeleteCommand) other;
-        return studentId.equals(otherDeleteCommand.studentId);
+        return studentId.equals(otherDeleteCommand.studentId)
+                && (module == null
+                        ? otherDeleteCommand.module == null
+                        : module.equals(otherDeleteCommand.module));
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .add("targetStudentId", studentId)
+                .add("module", module)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -41,7 +40,7 @@ public class EditCommand extends Command {
             + "by the studentId assigned to the corresponding student. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: STUDENTID (must be a valid and existing 8-digit Student ID) "
-            + "[" + PREFIX_STUDENTID + "STUDENTID] "
+            + "[" + "STUDENTID] "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
@@ -171,7 +170,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(studentId, name, phone, email, address, course, tag, modules);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, course, tag, modules);
         }
 
         public void setStudentId(StudentId studentId) {

--- a/src/main/java/seedu/address/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GradeCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
@@ -26,12 +25,12 @@ public class GradeCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a course-specific grade to a student. "
             + "Parameters: "
-            + PREFIX_STUDENTID + "ID "
+            + "ID "
             + PREFIX_MODULE + "MODULE "
             + PREFIX_GRADE + "GRADE "
             + "\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_STUDENTID + "12345678 "
+            + "12345678 "
             + PREFIX_MODULE + "CS2103T "
             + PREFIX_GRADE + "A+ ";
 

--- a/src/main/java/seedu/address/logic/commands/ModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ModuleCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
@@ -24,11 +23,11 @@ public class ModuleCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to a student. "
             + "Parameters: "
-            + PREFIX_STUDENTID + "ID "
+            + "ID "
             + PREFIX_MODULE + "MODULE "
             + "\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_STUDENTID + "12345678 "
+            + "12345678 "
             + PREFIX_MODULE + "CS2103T ";
 
     public static final String MESSAGE_SUCCESS = "New module added for Student %1$s";

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.stream.Stream;
@@ -34,18 +33,20 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_STUDENTID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS, PREFIX_COURSE, PREFIX_TAG);
+        String preamble = argMultimap.getPreamble();
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENTID, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_COURSE)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL,
+                PREFIX_COURSE)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STUDENTID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_ADDRESS, PREFIX_COURSE);
-        StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENTID).get());
+        argMultimap.verifyNoDuplicateStudentId(args);
+        StudentId studentId = ParserUtil.parseStudentId(preamble);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,33 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Verifies that there is no more than one StudentId present in the preamble.
+     * If multiple StudentIds are found, this method throws a {@code ParseException}.
+     *
+     * @throws ParseException if multiple StudentIds are present in the arguments.
+     */
+    public void verifyNoDuplicateStudentId(String input) throws ParseException {
+        String trimmedInput = input.trim();
+        String[] tokens = trimmedInput.split("\\s+");
+        int count = 0;
+        for (String token : tokens) {
+            if (!token.startsWith("m/") && !token.startsWith("g/")
+                    && !token.startsWith("n/") && !token.startsWith("p/")
+                    && !token.startsWith("e/") && !token.startsWith("a/")
+                    && !token.startsWith("c/") && !token.startsWith("t/")) {
+
+                boolean isStudentId = token.matches("^[!?&@]*\\d{7,8}$")
+                        || token.matches("^[A-Za-z]\\d{7}[A-Za-z]?$");
+
+                if (isStudentId) {
+                    count++;
+                }
+            }
+        }
+        if (count > 1) {
+            throw new ParseException(Messages.getErrorMessageForDuplicateID());
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,13 +6,13 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_STUDENTID = new Prefix("id/");
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_COURSE = new Prefix("c/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+
     public static final Prefix PREFIX_MODULE = new Prefix("m/");
     public static final Prefix PREFIX_GRADE = new Prefix("g/");
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,9 +1,11 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.StudentId;
 
 /**
@@ -18,19 +20,22 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         String trimmedArg = args.trim();
-        try {
-            if (!trimmedArg.startsWith("id/")) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-            }
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_MODULE);
+        argMultimap.verifyNoDuplicateStudentId(args);
 
-            String studentIdString = trimmedArg.substring(3).trim();
-            StudentId studentId = ParserUtil.parseStudentId(studentIdString);
-            return new DeleteCommand(studentId);
-
-        } catch (IllegalArgumentException e) {
+        if (trimmedArg.isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), e);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
+
+        String studentIdString = argMultimap.getPreamble(); // Assuming preamble is used for ID
+        StudentId studentId = ParserUtil.parseStudentId(studentIdString);
+
+        if (argMultimap.getValue(PREFIX_MODULE).isPresent()) {
+            String moduleName = argMultimap.getValue(PREFIX_MODULE).get();
+            Module module = ParserUtil.parseModule(moduleName);
+            return new DeleteCommand(studentId, module);
+        }
+        return new DeleteCommand(studentId);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.EditCommand;
@@ -30,25 +29,25 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_STUDENTID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                        PREFIX_ADDRESS, PREFIX_COURSE, PREFIX_TAG, PREFIX_MODULE);
-
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_COURSE, PREFIX_TAG, PREFIX_MODULE);
         StudentId studentId;
-
         try {
             studentId = ParserUtil.parseStudentId(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STUDENTID, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ADDRESS, PREFIX_COURSE);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                PREFIX_COURSE);
+        argMultimap.verifyNoDuplicateStudentId(args);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
-        if (argMultimap.getValue(PREFIX_STUDENTID).isPresent()) {
-            editPersonDescriptor.setStudentId(ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENTID).get()));
+        if (!argMultimap.getPreamble().isEmpty()) {
+            editPersonDescriptor.setStudentId(ParserUtil.parseStudentId(argMultimap.getPreamble()));
         }
+
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             editPersonDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
         }

--- a/src/main/java/seedu/address/logic/parser/GradeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GradeCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 
 import java.util.stream.Stream;
 
@@ -25,15 +24,17 @@ public class GradeCommandParser implements Parser<GradeCommand> {
      */
     public GradeCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_STUDENTID, PREFIX_MODULE, PREFIX_GRADE);
+                ArgumentTokenizer.tokenize(args, PREFIX_MODULE, PREFIX_GRADE);
+        String preamble = argMultimap.getPreamble();
+        argMultimap.verifyNoDuplicateStudentId(args);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENTID, PREFIX_MODULE, PREFIX_GRADE)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_MODULE, PREFIX_GRADE)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STUDENTID, PREFIX_MODULE, PREFIX_GRADE);
-        StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENTID).get());
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_MODULE, PREFIX_GRADE);
+
+        StudentId studentId = ParserUtil.parseStudentId(preamble);
         Grade grade = ParserUtil.parseGrade(argMultimap.getValue(PREFIX_GRADE).get());
         Module module = ParserUtil.parseModule(argMultimap.getValue(PREFIX_MODULE).get());
 
@@ -47,5 +48,4 @@ public class GradeCommandParser implements Parser<GradeCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/ModuleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ModuleCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 
 import java.util.stream.Stream;
 
@@ -23,15 +22,16 @@ public class ModuleCommandParser implements Parser<ModuleCommand> {
      */
     public ModuleCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_STUDENTID, PREFIX_MODULE);
+                ArgumentTokenizer.tokenize(args, PREFIX_MODULE);
+        String preamble = argMultimap.getPreamble();
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_STUDENTID, PREFIX_MODULE)
-                || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_MODULE)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_STUDENTID, PREFIX_MODULE);
-        StudentId studentId = ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENTID).get());
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_MODULE);
+        argMultimap.verifyNoDuplicateStudentId(args);
+        StudentId studentId = ParserUtil.parseStudentId(preamble);
         Module module = ParserUtil.parseModule(argMultimap.getValue(PREFIX_MODULE).get());
 
         return new ModuleCommand(studentId, module);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -88,6 +88,10 @@ public class AddressBook implements ReadOnlyAddressBook {
             throw new IllegalArgumentException("Person not found in the address book.");
         }
 
+        if (persons.contains(person)) {
+            person.addModule(module);
+        }
+
         Person updatedPerson = person.addModule(module);
         setPerson(person, updatedPerson);
     }
@@ -123,6 +127,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         if (!hasPerson(person)) {
             throw new IllegalArgumentException("Person not found in the address book.");
         }
+
+        if (!person.getModules().contains(module)) {
+            throw new IllegalArgumentException("Module not found in person's list.");
+        }
+
         Person updatedPerson = person.deleteModule(module);
         setPerson(person, updatedPerson);
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -76,6 +77,22 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Adds a module to the person in address book.
+     * The person must not already exist in the address book.
+     */
+    public void addModule(Person person, Module module) {
+        requireNonNull(person);
+        requireNonNull(module);
+
+        if (!hasPerson(person)) {
+            throw new IllegalArgumentException("Person not found in the address book.");
+        }
+
+        Person updatedPerson = person.addModule(module);
+        setPerson(person, updatedPerson);
+    }
+
+    /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the address book.
      * The person identity of {@code editedPerson} must not be the same as another existing person in the address book.
@@ -92,6 +109,22 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+    }
+
+
+    /**
+     * Removes {@code module} from {@code person} in AddressBook.
+     * {@code person} must exist in the address book.
+     */
+    public void removeModule(Person person, Module module) {
+        requireNonNull(person);
+        requireNonNull(module);
+
+        if (!hasPerson(person)) {
+            throw new IllegalArgumentException("Person not found in the address book.");
+        }
+        Person updatedPerson = person.deleteModule(module);
+        setPerson(person, updatedPerson);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.Person;
 
 /**
@@ -64,10 +65,21 @@ public interface Model {
     void deletePerson(Person target);
 
     /**
+     * Deletes the given module for the given person.
+     * The person and the corresponding module must exist in the address book.
+     */
+    void deleteModule(Person target, Module module);
+
+    /**
      * Adds the given person.
      * {@code person} must not already exist in the address book.
      */
     void addPerson(Person person);
+
+    /**
+     * Adds the given module to the given person.
+     */
+    void addModule(Person target, Module module);
 
     /**
      * Replaces the given person {@code target} with {@code editedPerson}.
@@ -95,4 +107,5 @@ public interface Model {
      * Returns the Person object to display.
      */
     Person getPersonToDisplay();
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.Person;
 
 /**
@@ -117,10 +118,22 @@ public class ModelManager implements Model {
             setPersonToDisplay(null);
         }
     }
+    @Override
+    public void deleteModule(Person target, Module module) {
+        addressBook.removeModule(target, module);
+    }
 
     @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
+
+        setPersonToDisplay(person);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
+
+    @Override
+    public void addModule(Person person, Module module) {
+        addressBook.addModule(person, module);
 
         setPersonToDisplay(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -132,6 +132,29 @@ public class Person {
     }
 
     /**
+     * Returns a new Person object after deletion of a specified module.
+     */
+    public Person deleteModule(Module module) {
+        requireNonNull(module, "Module cannot be null");
+
+        ArrayList<Module> updatedModules = new ArrayList<>(modules);
+
+        updatedModules.remove(module);
+        return new Person(studentId, name, phone, email, address, course, tag, updatedModules);
+    }
+
+    /**
+     * Returns true if the person has the specified module.
+     *
+     * @param module The module to check.
+     * @return true if the person has the module, false otherwise.
+     */
+    public boolean hasModule(Module module) {
+        requireNonNull(module, "Module cannot be null");
+        return modules.contains(module);
+    }
+
+    /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -63,7 +63,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete id/00000000";
+        String deleteCommand = "delete 00000000";
         assertCommandException(deleteCommand, String.format(DeleteCommand.MESSAGE_PERSON_NOT_FOUND, "00000000"));
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
 
@@ -96,11 +97,13 @@ public class AddCommandTest {
 
         @Override
         public ReadOnlyUserPrefs getUserPrefs() {
+
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public GuiSettings getGuiSettings() {
+
             throw new AssertionError("This method should not be called.");
         }
 
@@ -111,6 +114,7 @@ public class AddCommandTest {
 
         @Override
         public Path getAddressBookFilePath() {
+
             throw new AssertionError("This method should not be called.");
         }
 
@@ -121,6 +125,12 @@ public class AddCommandTest {
 
         @Override
         public void addPerson(Person person) {
+
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addModule(Person person, Module module) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -131,16 +141,24 @@ public class AddCommandTest {
 
         @Override
         public ReadOnlyAddressBook getAddressBook() {
+
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public boolean hasPerson(Person person) {
+
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public void deletePerson(Person target) {
+
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteModule(Person target, Module module) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -49,8 +48,8 @@ public class CommandTestUtil {
     public static final String VALID_MODULE_BOB = "CS2100";
     public static final String VALID_GRADE_BOB = "B+";
 
-    public static final String STUDENTID_DESC_AMY = " " + PREFIX_STUDENTID + VALID_STUDENTID_AMY;
-    public static final String STUDENTID_DESC_BOB = " " + PREFIX_STUDENTID + VALID_STUDENTID_BOB;
+    public static final String STUDENTID_DESC_AMY = " " + VALID_STUDENTID_AMY;
+    public static final String STUDENTID_DESC_BOB = " " + VALID_STUDENTID_BOB;
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
@@ -68,8 +67,7 @@ public class CommandTestUtil {
     public static final String GRADE_DESC_AMY = " " + PREFIX_GRADE + VALID_GRADE_AMY;
     public static final String GRADE_DESC_BOB = " " + PREFIX_GRADE + VALID_GRADE_BOB;
 
-    public static final String INVALID_STUDENTID_DESC = " " + PREFIX_STUDENTID
-            + "@1234567"; // '@' not allowed in studentIds
+    public static final String INVALID_STUDENTID_DESC = " " + "@1234567"; // '@' not allowed in studentIds
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -12,11 +12,11 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
-//import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.StudentId;
 
@@ -39,6 +39,9 @@ public class DeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
+
+        System.out.println(deleteCommand + "\n" + expectedMessage + "\n");
+        System.out.println(model + "\n" + expectedModel + "\n");
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
@@ -136,7 +139,8 @@ public class DeleteCommandTest {
         StudentId targetStudentId = firstPerson.getStudentId();
 
         DeleteCommand deleteCommand = new DeleteCommand(targetStudentId);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetStudentId=" + targetStudentId + "}";
+        String expected = DeleteCommand.class.getCanonicalName() + "{targetStudentId=" + targetStudentId
+                + ", module=" + null + "}";
         assertEquals(expected, deleteCommand.toString());
     }
 
@@ -148,4 +152,37 @@ public class DeleteCommandTest {
 
         assertTrue(model.getFilteredPersonList().isEmpty());
     }
+
+    @Test
+    public void execute_invalidModuleToDelete_throwsCommandException() {
+        Person personWithNoModule = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        StudentId studentIdToDelete = personWithNoModule.getStudentId();
+        Module nonExistentModule = new Module("CS9999");
+
+        DeleteCommand deleteCommand = new DeleteCommand(studentIdToDelete, nonExistentModule);
+        assertCommandFailure(
+                deleteCommand, model, String.format(DeleteCommand.MESSAGE_MODULE_NOT_FOUND, studentIdToDelete));
+    }
+
+    @Test
+    public void execute_deleteModule_whenNoModules() {
+        Person personWithoutModules = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        StudentId studentIdToDelete = personWithoutModules.getStudentId();
+        Module moduleToDelete = new Module("CS2103T");
+
+        DeleteCommand deleteCommand = new DeleteCommand(studentIdToDelete, moduleToDelete);
+        assertCommandFailure(
+                deleteCommand, model, String.format(DeleteCommand.MESSAGE_MODULE_NOT_FOUND, studentIdToDelete));
+    }
+
+    @Test
+    public void execute_invalidStudentIdWithModule_throwsCommandException() {
+        StudentId invalidStudentId = new StudentId("12345679");
+        Module moduleToDelete = new Module("CS2103T");
+        DeleteCommand deleteCommand = new DeleteCommand(invalidStudentId, moduleToDelete);
+
+        assertCommandFailure(
+                deleteCommand, model, String.format(DeleteCommand.MESSAGE_PERSON_NOT_FOUND, invalidStudentId));
+    }
+
 }

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -16,7 +16,6 @@ import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_BOB;
@@ -31,7 +30,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -77,7 +75,7 @@ public class AddCommandParserTest {
                 + ADDRESS_DESC_BOB + COURSE_DESC_BOB + TAG_DESC_STUDENT;
 
         // multiple names
-        assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
+        assertParseFailure(parser, validExpectedPersonString + NAME_DESC_AMY,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME));
 
         // multiple phones
@@ -96,7 +94,7 @@ public class AddCommandParserTest {
         assertParseFailure(parser,
                 validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY
                         + ADDRESS_DESC_AMY + validExpectedPersonString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_STUDENTID, PREFIX_COURSE,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_COURSE,
                         PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
 
         // invalid value followed by valid value
@@ -196,9 +194,9 @@ public class AddCommandParserTest {
         assertParseFailure(parser, STUDENTID_DESC_BOB + INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + INVALID_ADDRESS_DESC + COURSE_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
 
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + STUDENTID_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB
-                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + COURSE_DESC_BOB + TAG_DESC_STUDENT,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        //        // non-empty preamble
+        //        assertParseFailure(parser, PREAMBLE_NON_EMPTY + STUDENTID_DESC_BOB + NAME_DESC_BOB + PHONE_DESC_BOB
+        //                        + EMAIL_DESC_BOB + ADDRESS_DESC_BOB + COURSE_DESC_BOB + TAG_DESC_STUDENT,
+        //                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.Arrays;
@@ -61,7 +60,7 @@ public class AddressBookParserTest {
     public void parseCommand_delete() throws Exception {
         StudentId validStudentId = new StudentId("12345678");
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + PREFIX_STUDENTID + validStudentId);
+                DeleteCommand.COMMAND_WORD + " " + validStudentId);
         assertEquals(new DeleteCommand(validStudentId), command);
     }
 
@@ -71,10 +70,7 @@ public class AddressBookParserTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).setEmptyModuleList().build();
         StudentId studentId = person.getStudentId();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + studentId + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
-
-        EditCommand expected = new EditCommand(studentId, descriptor);
-
+                + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(studentId, descriptor), command);
     }
 
@@ -127,7 +123,7 @@ public class AddressBookParserTest {
         StudentId validStudentId = new StudentId(CommandTestUtil.VALID_STUDENTID_BOB);
         Module validModule = new Module(CommandTestUtil.VALID_MODULE_BOB);
         ModuleCommand command = (ModuleCommand) parser.parseCommand(
-                ModuleCommand.COMMAND_WORD + " " + PREFIX_STUDENTID + validStudentId + " "
+                ModuleCommand.COMMAND_WORD + " " + validStudentId + " "
                         + PREFIX_MODULE + validModule.value);
         assertEquals(new ModuleCommand(validStudentId, validModule), command);
     }
@@ -137,8 +133,9 @@ public class AddressBookParserTest {
         StudentId validStudentId = new StudentId(CommandTestUtil.VALID_STUDENTID_BOB);
         Module validModule = new Module(CommandTestUtil.VALID_MODULE_BOB);
         Grade validGrade = new Grade(CommandTestUtil.VALID_GRADE_BOB);
+        System.out.println("this");
         GradeCommand command = (GradeCommand) parser.parseCommand(
-                GradeCommand.COMMAND_WORD + " " + PREFIX_STUDENTID + validStudentId + " "
+                GradeCommand.COMMAND_WORD + " " + validStudentId + " "
                         + PREFIX_MODULE + validModule.value + " " + PREFIX_GRADE + validGrade);
         assertEquals(new GradeCommand(validStudentId, validModule, validGrade), command);
     }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.StudentId;
 
 /**
@@ -23,12 +23,35 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_validArgs_returnsDeleteCommand() {
         StudentId validStudentId = new StudentId("12345678");
-        String input = "id/" + validStudentId;
+        String input = "" + validStudentId;
         assertParseSuccess(parser, input, new DeleteCommand(validStudentId));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", StudentId.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_validArgsWithModule_returnsDeleteCommand() {
+        StudentId validStudentId = new StudentId("12345678");
+        Module validModule = new Module("CS2103T");
+        String input = "12345678 m/CS2103T";
+
+        assertParseSuccess(parser, input, new DeleteCommand(validStudentId, validModule));
+    }
+
+    @Test
+    public void parse_validArgsWithoutModule_returnsDeleteCommand() {
+        StudentId validStudentId = new StudentId("12345678");
+        String input = "12345678";
+
+        assertParseSuccess(parser, input, new DeleteCommand(validStudentId));
+    }
+
+    @Test
+    public void parse_invalidModuleFormat_throwsParseException() {
+        String input = "12345678 m/ Invalid_Module!";
+        assertParseFailure(parser, input, Module.MESSAGE_CONSTRAINTS);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -79,9 +79,7 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "12" + INVALID_STUDENTID_DESC, MESSAGE_INVALID_FORMAT); // invalid studentID preamble
-        assertParseFailure(parser, "12345678"
-                + INVALID_STUDENTID_DESC, StudentId.MESSAGE_CONSTRAINTS); // invalid studentID
+        assertParseFailure(parser, INVALID_STUDENTID_DESC, MESSAGE_INVALID_FORMAT); // invalid studentID
         assertParseFailure(parser, "12345678" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "12345678" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "12345678" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
@@ -103,7 +101,8 @@ public class EditCommandParserTest {
         String userInput = studentId + PHONE_DESC_BOB + TAG_DESC_TUTOR
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_STUDENT;
 
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withStudentId(studentId)
+                .withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTag(VALID_TAG_STUDENT).build();
         EditCommand expectedCommand = new EditCommand(new StudentId(studentId), descriptor);
@@ -116,8 +115,11 @@ public class EditCommandParserTest {
         String studentId = "12345678";
         String userInput = studentId + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
-                .withEmail(VALID_EMAIL_AMY).build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withStudentId(studentId)
+                .withPhone(VALID_PHONE_BOB)
+                .withEmail(VALID_EMAIL_AMY)
+                .build();
         EditCommand expectedCommand = new EditCommand(new StudentId(studentId), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -129,31 +131,46 @@ public class EditCommandParserTest {
 
         // name
         String userInput = studentId + NAME_DESC_AMY;
-        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY).build();
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder()
+                .withStudentId(studentId)
+                .withName(VALID_NAME_AMY)
+                .build();
         EditCommand expectedCommand = new EditCommand(new StudentId(studentId), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
         userInput = studentId + PHONE_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        descriptor = new EditPersonDescriptorBuilder()
+                .withStudentId(studentId)
+                .withPhone(VALID_PHONE_AMY)
+                .build();
         expectedCommand = new EditCommand(new StudentId(studentId), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
         userInput = studentId + EMAIL_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
+        descriptor = new EditPersonDescriptorBuilder()
+                .withStudentId(studentId)
+                .withEmail(VALID_EMAIL_AMY)
+                .build();
         expectedCommand = new EditCommand(new StudentId(studentId), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // address
         userInput = studentId + ADDRESS_DESC_AMY;
-        descriptor = new EditPersonDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
+        descriptor = new EditPersonDescriptorBuilder()
+                .withStudentId(studentId)
+                .withAddress(VALID_ADDRESS_AMY)
+                .build();
         expectedCommand = new EditCommand(new StudentId(studentId), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // tags
         userInput = studentId + TAG_DESC_STUDENT;
-        descriptor = new EditPersonDescriptorBuilder().withTag(VALID_TAG_STUDENT).build();
+        descriptor = new EditPersonDescriptorBuilder()
+                .withStudentId(studentId)
+                .withTag(VALID_TAG_STUDENT)
+                .build();
         expectedCommand = new EditCommand(new StudentId(studentId), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/logic/parser/GradeCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GradeCommandParserTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_STUDENTID_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_BOB;
@@ -17,7 +16,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENTID_BOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GRADE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -48,8 +46,9 @@ public class GradeCommandParserTest {
         String validExpectedGradeString = STUDENTID_DESC_AMY + MODULE_DESC_AMY + GRADE_DESC_AMY;
 
         // multiple studentIds
+        System.out.println(STUDENTID_DESC_AMY + validExpectedGradeString);
         assertParseFailure(parser, STUDENTID_DESC_AMY + validExpectedGradeString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+                Messages.getErrorMessageForDuplicateID());
 
         // multiple modules
         assertParseFailure(parser, MODULE_DESC_AMY + validExpectedGradeString,
@@ -61,15 +60,15 @@ public class GradeCommandParserTest {
 
         // multiple fields repeated
         assertParseFailure(parser,
-                validExpectedGradeString + STUDENTID_DESC_AMY + MODULE_DESC_AMY + GRADE_DESC_AMY
+                STUDENTID_DESC_AMY + validExpectedGradeString + MODULE_DESC_AMY + GRADE_DESC_AMY
                         + validExpectedGradeString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID, PREFIX_MODULE, PREFIX_GRADE));
+                Messages.getErrorMessageForDuplicateID());
 
         // invalid value followed by valid value
 
         // invalid studentId
         assertParseFailure(parser, INVALID_STUDENTID_DESC + validExpectedGradeString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+                Messages.getErrorMessageForDuplicateID());
 
         // invalid module
         assertParseFailure(parser, INVALID_MODULE_DESC + validExpectedGradeString,
@@ -82,8 +81,8 @@ public class GradeCommandParserTest {
         // valid value followed by invalid value
 
         // invalid studentId
-        assertParseFailure(parser, validExpectedGradeString + INVALID_STUDENTID_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+        assertParseFailure(parser, validExpectedGradeString + INVALID_STUDENTID_DESC ,
+                Messages.getErrorMessageForDuplicateID());
 
         // invalid module
         assertParseFailure(parser, validExpectedGradeString + INVALID_MODULE_DESC,
@@ -98,8 +97,8 @@ public class GradeCommandParserTest {
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeCommand.MESSAGE_USAGE);
 
-        // missing studentId prefix
-        assertParseFailure(parser, VALID_STUDENTID_BOB + MODULE_DESC_BOB + GRADE_DESC_BOB, expectedMessage);
+        //        // missing studentId prefix
+        //        assertParseFailure(parser, VALID_STUDENTID_BOB + MODULE_DESC_BOB + GRADE_DESC_BOB, expectedMessage);
 
         // missing module prefix
         assertParseFailure(parser, STUDENTID_DESC_BOB + VALID_MODULE_BOB + GRADE_DESC_BOB, expectedMessage);
@@ -129,8 +128,8 @@ public class GradeCommandParserTest {
         assertParseFailure(parser, INVALID_STUDENTID_DESC + INVALID_MODULE_DESC + GRADE_DESC_BOB,
                 StudentId.MESSAGE_CONSTRAINTS);
 
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + STUDENTID_DESC_BOB + MODULE_DESC_BOB + GRADE_DESC_BOB,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeCommand.MESSAGE_USAGE));
+        //        // non-empty preamble
+        //        assertParseFailure(parser, PREAMBLE_NON_EMPTY + STUDENTID_DESC_BOB + MODULE_DESC_BOB + GRADE_DESC_BOB,
+        //                String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ModuleCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ModuleCommandParserTest.java
@@ -5,14 +5,12 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_STUDENTID_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.MODULE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.STUDENTID_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STUDENTID_BOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -42,22 +40,22 @@ public class ModuleCommandParserTest {
 
         // multiple studentIds
         assertParseFailure(parser, STUDENTID_DESC_AMY + validExpectedModuleString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+                Messages.getErrorMessageForDuplicateID());
 
         // multiple modules
-        assertParseFailure(parser, MODULE_DESC_AMY + validExpectedModuleString,
+        assertParseFailure(parser, validExpectedModuleString + MODULE_DESC_AMY,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULE));
 
         // multiple fields repeated
         assertParseFailure(parser,
                 validExpectedModuleString + STUDENTID_DESC_AMY + MODULE_DESC_AMY + validExpectedModuleString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID, PREFIX_MODULE));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_MODULE));
 
         // invalid value followed by valid value
 
         // invalid studentId
         assertParseFailure(parser, INVALID_STUDENTID_DESC + validExpectedModuleString,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+                Messages.getErrorMessageForDuplicateID());
 
         // invalid module
         assertParseFailure(parser, INVALID_MODULE_DESC + validExpectedModuleString,
@@ -67,7 +65,7 @@ public class ModuleCommandParserTest {
 
         // invalid studentId
         assertParseFailure(parser, validExpectedModuleString + INVALID_STUDENTID_DESC,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_STUDENTID));
+                 Messages.getErrorMessageForDuplicateID());
 
         // invalid module
         assertParseFailure(parser, validExpectedModuleString + INVALID_MODULE_DESC,
@@ -77,9 +75,6 @@ public class ModuleCommandParserTest {
     @Test
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleCommand.MESSAGE_USAGE);
-
-        // missing studentId prefix
-        assertParseFailure(parser, VALID_STUDENTID_BOB + MODULE_DESC_BOB, expectedMessage);
 
         // missing module prefix
         assertParseFailure(parser, STUDENTID_DESC_BOB + VALID_MODULE_BOB, expectedMessage);
@@ -100,8 +95,8 @@ public class ModuleCommandParserTest {
         assertParseFailure(parser, INVALID_STUDENTID_DESC + INVALID_MODULE_DESC,
                 StudentId.MESSAGE_CONSTRAINTS);
 
-        // non-empty preamble
-        assertParseFailure(parser, PREAMBLE_NON_EMPTY + STUDENTID_DESC_BOB + MODULE_DESC_BOB,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleCommand.MESSAGE_USAGE));
+        //        // non-empty preamble
+        //        assertParseFailure(parser, PREAMBLE_NON_EMPTY + STUDENTID_DESC_BOB + MODULE_DESC_BOB,
+        //                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ModuleCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -55,6 +56,11 @@ public class AddressBookTest {
     }
 
     @Test
+    public void addPerson_nullPerson_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.addPerson(null));
+    }
+
+    @Test
     public void hasPerson_nullPerson_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> addressBook.hasPerson(null));
     }
@@ -76,6 +82,25 @@ public class AddressBookTest {
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTag(VALID_TAG_TUTOR)
                 .build();
         assertTrue(addressBook.hasPerson(editedAlice));
+    }
+
+    @Test
+    public void addModule_personNotInAddressBook_throwsIllegalArgumentException() {
+        Module module = new Module("CS2101");
+        assertThrows(IllegalArgumentException.class, () -> addressBook.addModule(ALICE, module));
+    }
+
+    @Test
+    public void removeModule_personNotInAddressBook_throwsIllegalArgumentException() {
+        Module module = new Module("CS2101");
+        assertThrows(IllegalArgumentException.class, () -> addressBook.removeModule(ALICE, module));
+    }
+
+    @Test
+    public void removeModule_moduleNotInPerson_throwsIllegalArgumentException() {
+        addressBook.addPerson(ALICE);
+        Module module = new Module("CS2101");
+        assertThrows(IllegalArgumentException.class, () -> addressBook.removeModule(ALICE, module));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -129,7 +129,6 @@ public class ModelManagerTest {
         // different person -> returns false
         assertNotEquals(BENSON, modelManager.getPersonToDisplay());
     }
-    
     @Test
     public void addModule_invalidPerson_throwsException() {
         Module module = new Module("CS2101");

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.person.Module;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
@@ -128,7 +129,18 @@ public class ModelManagerTest {
         // different person -> returns false
         assertNotEquals(BENSON, modelManager.getPersonToDisplay());
     }
+    
+    @Test
+    public void addModule_invalidPerson_throwsException() {
+        Module module = new Module("CS2101");
+        assertThrows(IllegalArgumentException.class, () -> modelManager.addModule(BENSON, module));
+    }
 
+    @Test
+    public void deleteModule_invalidPerson_throwsException() {
+        Module module = new Module("CS2101");
+        assertThrows(IllegalArgumentException.class, () -> modelManager.deleteModule(BENSON, module));
+    }
     @Test
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -132,6 +132,50 @@ public class PersonTest {
     }
 
     @Test
+    public void deleteModule_moduleExists_moduleRemoved() {
+        Person person = new PersonBuilder().build();
+        Module module = new Module(CommandTestUtil.VALID_MODULE_AMY);
+        person = person.addModule(module);
+
+        Person personAfterDeletion = person.deleteModule(module);
+
+        assertFalse(personAfterDeletion.hasModule(module));
+        assertEquals(0, personAfterDeletion.getModules().size());
+    }
+
+    @Test
+    public void setModules_updatesModulesCorrectly() {
+        Person person = new PersonBuilder().build();
+        Module module1 = new Module(CommandTestUtil.VALID_MODULE_AMY);
+        Module module2 = new Module(CommandTestUtil.VALID_MODULE_BOB);
+        ArrayList<Module> newModules = new ArrayList<>();
+        newModules.add(module1);
+        newModules.add(module2);
+
+        person.setModules(newModules);
+
+        assertEquals(newModules.size(), person.getModules().size());
+        assertTrue(person.hasModule(module1));
+        assertTrue(person.hasModule(module2));
+    }
+    @Test
+    public void hasModule_moduleExists_returnsTrue() {
+        Person person = new PersonBuilder().build();
+        Module module = new Module(CommandTestUtil.VALID_MODULE_AMY);
+        person = person.addModule(module);
+
+        assertTrue(person.hasModule(module));
+    }
+
+    @Test
+    public void hasModule_moduleDoesNotExist_returnsFalse() {
+        Person person = new PersonBuilder().build();
+        Module module = new Module(CommandTestUtil.VALID_MODULE_AMY);
+
+        assertFalse(person.hasModule(module));
+    }
+
+    @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{studentId=" + ALICE.getStudentId() + ", name="
                 + ALICE.getName() + ", phone=" + ALICE.getPhone()

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MODULE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENTID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.AddCommand;
@@ -30,7 +29,7 @@ public class PersonUtil {
      */
     public static String getPersonDetails(Person person) {
         StringBuilder sb = new StringBuilder();
-        sb.append(PREFIX_STUDENTID + person.getStudentId().value + " ");
+        sb.append(person.getStudentId().value + " ");
         sb.append(PREFIX_NAME + person.getName().fullName + " ");
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
@@ -48,7 +47,7 @@ public class PersonUtil {
      */
     public static String getEditPersonDescriptorDetails(EditPersonDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
-        descriptor.getStudentId().ifPresent(studentId -> sb.append(PREFIX_STUDENTID).append(studentId.value)
+        descriptor.getStudentId().ifPresent(studentId -> sb.append(studentId.value)
                 .append(" "));
         descriptor.getName().ifPresent(name -> sb.append(PREFIX_NAME).append(name.fullName).append(" "));
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));


### PR DESCRIPTION
**Key Changes:**

- Refactor all commands to remove id prefix.
Commands no longer require the prefix `id/` to specify StudentID. Parser Classes and Tests for relevant Commands are subsequently updated to cater to this change. Preamble of arguments is now utilized for StudentID.

  Example: 
  - `add 12345678 n/John ...`
  - `delete 12345678`
  
- Add Delete by Module
User may delete a Module associated with a Student, by specifying the StudentID and Module with `delete` command.

  Example: 
   - `delete 1234567 m/CS2103T`

**Future Considerations:**
- More robust tests related to the use of Model needed for `delete` by modules
- Might need to improve the logic for `verifyNoDuplicateStudentId` and add more tests