### PR TITLE
Duplicate role undetected

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -71,7 +71,7 @@ public class DeleteCommand extends Command {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
         Person toDelete = null;
-        boolean PersonDetailsDeleted = false;
+        boolean personDetailsDeleted = false;
 
         for (Person person : lastShownList) {
             if (person.getStudentId().equals(studentId)) {
@@ -113,11 +113,11 @@ public class DeleteCommand extends Command {
 
         if (toDelete.isSamePerson(model.getPersonToDisplay())) {
             model.setPersonToDisplay(null);
-            PersonDetailsDeleted = true;
+            personDetailsDeleted = true;
         }
 
         model.deletePerson(toDelete);
-        if (PersonDetailsDeleted) {
+        if (personDetailsDeleted) {
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(toDelete)), true);
         }
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(toDelete)));

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -44,7 +44,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ADDRESS, PREFIX_COURSE);
+                PREFIX_ADDRESS, PREFIX_COURSE, PREFIX_ROLE);
         argMultimap.verifyNoDuplicateStudentId(args);
         StudentId studentId = ParserUtil.parseStudentId(preamble);
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -38,7 +38,7 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ADDRESS, PREFIX_COURSE, PREFIX_MODULE);
+                PREFIX_ADDRESS, PREFIX_COURSE, PREFIX_MODULE, PREFIX_ROLE);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -30,6 +30,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalPersons.AMY;
@@ -95,7 +96,7 @@ public class AddCommandParserTest {
                 validExpectedPersonString + PHONE_DESC_AMY + EMAIL_DESC_AMY + NAME_DESC_AMY
                         + ADDRESS_DESC_AMY + validExpectedPersonString,
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_COURSE,
-                        PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE));
+                        PREFIX_ADDRESS, PREFIX_EMAIL, PREFIX_PHONE, PREFIX_ROLE));
 
         // invalid value followed by valid value
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -157,7 +157,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_allFieldsSpecified_success() {
         String studentId = "12345678";
-        String userInput = studentId + PHONE_DESC_BOB + ROLE_DESC_TUTOR
+        String userInput = studentId + PHONE_DESC_BOB
                 + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + ROLE_DESC_STUDENT;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withStudentId(studentId)
@@ -256,7 +256,7 @@ public class EditCommandParserTest {
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + ROLE_DESC_TUTOR;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_ROLE));
 
         // multiple invalid values
         userInput = studentId + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC


### PR DESCRIPTION
This pull request includes several changes to improve the consistency and functionality of the `DeleteCommand`, `AddCommandParser`, and `EditCommandParser` classes, as well as updates to their respective test cases. The main changes involve fixing variable naming conventions and adding support for the `PREFIX_ROLE` prefix.

### Consistency Improvements:
* [`src/main/java/seedu/address/logic/commands/DeleteCommand.java`](diffhunk://#diff-0ad79039883cb0f751ba1e7eba706f053bf0dcc5052e21877932fbfd6131fd79L74-R74): Corrected variable naming from `PersonDetailsDeleted` to `personDetailsDeleted` to follow camelCase convention. [[1]](diffhunk://#diff-0ad79039883cb0f751ba1e7eba706f053bf0dcc5052e21877932fbfd6131fd79L74-R74) [[2]](diffhunk://#diff-0ad79039883cb0f751ba1e7eba706f053bf0dcc5052e21877932fbfd6131fd79L116-R120)

### Functionality Enhancements:
* [`src/main/java/seedu/address/logic/parser/AddCommandParser.java`](diffhunk://#diff-02598e3474ac0f9e2c8ce8c4c8b7b37dd61858a78a0d25a9e5a0164f21c91235L47-R47): Added `PREFIX_ROLE` to the list of prefixes to check for duplicates.
* [`src/main/java/seedu/address/logic/parser/EditCommandParser.java`](diffhunk://#diff-679694a67b9baa1949e346b32d50a81e557d9e1264574a45608a85ebc92f6452L41-R41): Added `PREFIX_ROLE` to the list of prefixes to check for duplicates.

### Test Case Updates:
* [`src/test/java/seedu/address/logic/parser/AddCommandParserTest.java`](diffhunk://#diff-9713c7ef1bbbef08629ca55b1501a4a600564116be3637486f03c98f3d683bb9R33): Updated tests to include `PREFIX_ROLE` in duplicate prefix checks. [[1]](diffhunk://#diff-9713c7ef1bbbef08629ca55b1501a4a600564116be3637486f03c98f3d683bb9R33) [[2]](diffhunk://#diff-9713c7ef1bbbef08629ca55b1501a4a600564116be3637486f03c98f3d683bb9L98-R99)
* [`src/test/java/seedu/address/logic/parser/EditCommandParserTest.java`](diffhunk://#diff-009c8dc8339da9c3a32d2b3e8d813418eb9ec613ee5e344728db9ee3a1e12557L160-R160): Updated tests to include `PREFIX_ROLE` in duplicate prefix checks and adjusted test cases to reflect the changes in the parser. [[1]](diffhunk://#diff-009c8dc8339da9c3a32d2b3e8d813418eb9ec613ee5e344728db9ee3a1e12557L160-R160) [[2]](diffhunk://#diff-009c8dc8339da9c3a32d2b3e8d813418eb9ec613ee5e344728db9ee3a1e12557L259-R259)

resolves #243 
resolves #249 