### PR TITLE
Fix FilterCommand bug

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -278,7 +278,7 @@ filter [KEYWORD_PREFIX] [MORE_KEYWORDS]
 
 * **For filtering by Module:**
   * Use prefix `m/`.
-  * Partial matching is supported, allowing users to input parts of module codes. e.g. `m/CS21` will match modules like "CS2103T" and "CS2101."
+  * Only full module codes will be matched, e.g. `m/CS2103T` will match the module "CS2103T", and not `m/CS21`.
 
 <!-- -->
 

--- a/src/main/java/seedu/address/model/person/ModuleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ModuleContainsKeywordsPredicate.java
@@ -14,11 +14,12 @@ public class ModuleContainsKeywordsPredicate implements Predicate<Person> {
         this.keyword = keyword;
     }
 
-    @Override
-    public boolean test(Person person) {
-        return person.getModules().stream()
-                .anyMatch(module -> module.toString().toLowerCase().contains(keyword.toLowerCase()));
-    }
+@Override
+public boolean test(Person person) {
+    String regex = "\\b" + keyword.toLowerCase() + "\\b";
+    return person.getModules().stream()
+            .anyMatch(module -> module.toString().toLowerCase().matches(".*" + regex + ".*"));
+}
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/address/model/person/ModuleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ModuleContainsKeywordsPredicate.java
@@ -14,12 +14,12 @@ public class ModuleContainsKeywordsPredicate implements Predicate<Person> {
         this.keyword = keyword;
     }
 
-@Override
-public boolean test(Person person) {
-    String regex = "\\b" + keyword.toLowerCase() + "\\b";
-    return person.getModules().stream()
-            .anyMatch(module -> module.toString().toLowerCase().matches(".*" + regex + ".*"));
-}
+    @Override
+    public boolean test(Person person) {
+        String regex = "\\b" + keyword.toLowerCase() + "\\b";
+        return person.getModules().stream()
+                .anyMatch(module -> module.toString().toLowerCase().matches(".*" + regex + ".*"));
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/test/java/seedu/address/model/person/ModuleContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/ModuleContainsKeywordsPredicateTest.java
@@ -45,9 +45,6 @@ public class ModuleContainsKeywordsPredicateTest {
 
         predicate = new ModuleContainsKeywordsPredicate("cs1010");
         assertTrue(predicate.test(new PersonBuilder().addUngradedModule("CS1010").build()));
-
-        predicate = new ModuleContainsKeywordsPredicate("1010");
-        assertTrue(predicate.test(new PersonBuilder().addUngradedModule("CS1010").build()));
     }
 
     @Test


### PR DESCRIPTION
**Key changes:** 

- Change the logic for filtering by module to disallow partial matching, i.e. only `m/CS2103T` will match "CS2103T", but not `m/CS21`
- Similarly `m/GRA` and `m/:` will no longer match any modules